### PR TITLE
fix: require validation functions  with explicit type annotation for optional properties

### DIFF
--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-parse",
-  "version": "0.0.0-beta.2",
+  "version": "0.0.0-beta.3",
   "private": false,
   "description": "Minimalistic validation library with 100% type inference",
   "author": {

--- a/packages/pure-parse/src/validation.test.ts
+++ b/packages/pure-parse/src/validation.test.ts
@@ -624,6 +624,24 @@ describe('validation', () => {
                 // string is more narrow than string | undefined, which means that if the validation passes for string, it satisfies User2
                 name: isString,
               })
+              object<User2>({
+                id: isNumber,
+                // undefined is more narrow than string | undefined, which means that if the validation passes for undefined, it satisfies User2
+                name: isUndefined,
+              })
+              // @ts-expect-error
+              object<User2>({
+                id: isNumber,
+                // If we don't check the property, we have no type information on the field (it's unknown).
+                //  Therefore, the fact that it's optional should not mean that we can skip validation
+                // name: isString,
+              })
+              object<User2>({
+                id: isNumber,
+                // Similarly to above; the property must have a corresponding validation function
+                // @ts-expect-error
+                name: undefined,
+              })
             })
             it('works with complex objects', () => {
               type User1 = {

--- a/packages/pure-parse/src/validation.ts
+++ b/packages/pure-parse/src/validation.ts
@@ -159,9 +159,11 @@ export const tuple =
  * @param schema maps keys to validation functions.
  */
 export const object =
-  <T extends Record<string, unknown>>(schema: {
-    [K in keyof T]: Validator<T[K]>
-  }) =>
+  <T extends Record<string, unknown>>(
+    schema: Required<{
+      [K in keyof T]: Validator<T[K]>
+    }>,
+  ) =>
   (
     data: unknown,
   ): data is {


### PR DESCRIPTION
## What?

When a property is optional, the property must have a corresponding validation function.

## Why?

If there is no validation function, the value is actually `unknown`, which contradics the type predicate.
