### PR TITLE
feat: differentiate between optional properties and undefinable properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,7 +2100,7 @@
       }
     },
     "packages/pure-parse": {
-      "version": "0.0.0-beta.2",
+      "version": "0.0.0-beta.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,7 +2100,7 @@
       }
     },
     "packages/pure-parse": {
-      "version": "0.0.0-beta.3",
+      "version": "0.0.0-beta.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-parse",
-  "version": "0.0.0-beta.3",
+  "version": "0.0.0-beta.4",
   "private": false,
   "description": "Minimalistic validation library with 100% type inference",
   "author": {

--- a/packages/pure-parse/src/validation.ts
+++ b/packages/pure-parse/src/validation.ts
@@ -115,7 +115,7 @@ type OptionalValidator<T> = { [optionalSymbol]: true } & ((
 ) => data is typeof optionalSymbol)
 
 /**
- * Create a union with `undefined`. Convenient when creating optional properties in objects. Alias for union([isUndefined, validator]).
+ * Represent an optional property, which is different from a required property that can be `undefined`.
  * @param validator
  */
 export const optional = <T>(validator: Validator<T>): OptionalValidator<T> =>
@@ -129,17 +129,24 @@ export const optional = <T>(validator: Validator<T>): OptionalValidator<T> =>
   }) as OptionalValidator<T>
 
 /**
- * Create a union with `undefined`. Convenient when creating nullable properties in objects. Alias for union([isNull, validator]).
+ * Create an optional property that also can be `null`. Convenient when creating optional nullable properties in objects. Alias for optional(union(isNull, validator)).
+ * @param validator
+ */
+export const optionalNullable = <T>(validator: Validator<T>) =>
+  optional(union(isNull, validator))
+
+/**
+ * Create a union with `null`. Convenient when creating nullable properties in objects. Alias for union(isNull, validator).
  * @param validator
  */
 export const nullable = <T>(validator: Validator<T>) => union(isNull, validator)
 
 /**
- * Create a union with `undefined`. Convenient when creating optional nullable properties in objects. Alias for union([isUndefined, isNull, validator]).
+ * Create a union with `undefined`, which is different from optional properties. Alias for union(isUndefined, validator).
  * @param validator
  */
-export const optionalNullable = <T>(validator: Validator<T>) =>
-  union(isUndefined, isNull, validator)
+export const undefineable = <T>(validator: Validator<T>) =>
+  union(isUndefined, validator)
 
 /*
  * Product Types


### PR DESCRIPTION
Differentiate between optional properties and required properties that can  be undefined

Previously, the following code would contain a type error at the end:

```
type TreeNode<T> = {
            data: T
          }

          const isTreeNode = <T>(
            isData: (data: unknown) => data is T,
          ): Validator<TreeNode<T>> =>
            object({
              // In v0.0.0-beta.3, this caused a problem with optional properties.
              // Because data can be undefined, it caused problems with the earlier
              // implementation of the type inferrence which treated optional properties
              // and undefinable properties identically
              data: isData,
            })
```

Because `data` is unknown, it can be undefined, which got interpreted as it being an optional property, which caused a conflict with `TreeNode` which has declared it as required.
