### PR TITLE
chore: fix entries in package.json

### DIFF
--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -28,8 +28,15 @@
   ],
   "type": "module",
   "module": "./dist/index.js",
-  "main": "./dist/index.umd.cjs",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-parse",
-  "version": "0.0.0-beta.3",
+  "version": "0.0.0-beta.4",
   "private": false,
   "description": "Minimalistic validation library with 100% type inference",
   "author": {

--- a/packages/pure-parse/vite.config.ts
+++ b/packages/pure-parse/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     lib: {
       // Could also be a dictionary or array of multiple entry points
       entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
-      name: 'tsis',
+      name: 'pureParse',
       fileName: 'index',
     },
     emptyOutDir: false,


### PR DESCRIPTION
When importing a names export from this library in a Vercel functions, it crashes:

> Error: Named export 'isString' not found. The requested module 'pure-parse' is a CommonJS module, which may not support all module.exports as named exports.
> CommonJS modules can always be imported via the default export, for example using:
> 
> import pkg from 'pure-parse';
> const { isString } = pkg;
> 
> [builder] module.exports as named exports.
> CommonJS modules can always be imported via the default export, for example using:
> 
> import pkg from 'pure-parse';
> const { isString } = pkg;
> 

## How to test? (optional)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
