### PR TITLE
fix: type inference for optional properties 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ There is a second category of higher order functions that construct new, custom 
 
 The third category is convenience functions for dealing with `null`, `undefined`, and optional properties:
 
-- `optional`–for optional properties
+- `optional`–for optional properties. This function is special; only validator functions constructed with `optional` can describe optional properties.
 - `optionalNullable`–for optional nullable properties
 - `nullable`–for unions with `null`
-- `undefineable`–for unions with `undefined`. If this is used for a property on an object, the property is still required.
+- `undefineable`–for unions with `undefined`. If this is used for a property on an object, the property is required–not optional–but can be set to `undefined`.
 
 By composing these higher order functions and primitives, you end up with a schema-like syntax that models your data:
 
@@ -112,13 +112,17 @@ const isUsers = array(
 
 See more examples below.
 
-### Inferring and Declaring Types
+### Inferring Types
 
 To infer the type from a validator function, use the `Infer` utility type:
 
 ```ts
 type Users = Infer<typeof isUsers>
 ```
+
+⚠️ Note: optional properties will be inferred as required–but undefinable–properties. (This is either due to limitations of TypeScript or the skill of the author.) At runtime, the property is still optional; it's just the inferred type that has a slight discrepancy. For most use cases, this is not a problem to worry about. If you are adamant on being correct, consider declaring the type instead of inferring it (see the following section). Future version of this library might provide a solution.
+
+### Declaring Types
 
 If you'd rather declare your type explicitly, annotate the validation functions with a type parameter:
 

--- a/packages/pure-parse/src/internals/Equals.ts
+++ b/packages/pure-parse/src/internals/Equals.ts
@@ -1,0 +1,5 @@
+export type Equals<T1, T2> = T1 extends T2
+  ? T2 extends T1
+    ? true
+    : false
+  : false

--- a/packages/pure-parse/src/internals/Equals.ts
+++ b/packages/pure-parse/src/internals/Equals.ts
@@ -1,3 +1,7 @@
+/**
+ * Check whether two types are equal. `true` if they are, `false` if not.
+ * Useful for testing generics.
+ */
 export type Equals<T1, T2> = T1 extends T2
   ? T2 extends T1
     ? true

--- a/packages/pure-parse/src/internals/hasKey.ts
+++ b/packages/pure-parse/src/internals/hasKey.ts
@@ -1,0 +1,8 @@
+/*
+ * Utility functions that are local to this library. They are not exposed.
+ */
+
+export const hasKey = <Key extends string | symbol>(
+  data: object,
+  key: Key,
+): data is { [K in Key]: unknown } => key in data

--- a/packages/pure-parse/src/internals/index.ts
+++ b/packages/pure-parse/src/internals/index.ts
@@ -1,0 +1,2 @@
+export * from './hasKey'
+export * from './Equals'

--- a/packages/pure-parse/src/internals/index.ts
+++ b/packages/pure-parse/src/internals/index.ts
@@ -1,2 +1,3 @@
 export * from './hasKey'
 export * from './Equals'
+export * from './utility-types'

--- a/packages/pure-parse/src/internals/utility-types.ts
+++ b/packages/pure-parse/src/internals/utility-types.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a union of all keys that are required
+ */
+export type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T]
+
+/**
+ * Returns a union of all keys that are required
+ */
+export type OptionalKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never
+}[keyof T]

--- a/packages/pure-parse/src/validation.test.ts
+++ b/packages/pure-parse/src/validation.test.ts
@@ -473,14 +473,6 @@ describe('validation', () => {
         })
       })
       describe('optional', () => {
-        describe('OptionalValidator', () => {
-          test('that Validator and OptionalValidator are mutually exclusive', () => {
-            const a1: Equals<
-              Validator<string>,
-              OptionalValidator<string>
-            > = false
-          })
-        })
         it('matches undefined', () => {
           expect(optional(isString)(undefined)).toEqual(true)
         })

--- a/packages/pure-parse/src/validation.ts
+++ b/packages/pure-parse/src/validation.ts
@@ -1,11 +1,10 @@
+import { hasKey, OptionalKeys, RequiredKeys } from './internals'
 /*
  * Utility Types
  */
 
-import { hasKey } from './internals'
-
 /**
- * A function that return a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates) on the argument.
+ * A function that returns a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates) on the argument.
  */
 export type Validator<T> = (data: unknown) => data is T
 
@@ -17,7 +16,7 @@ export type Infer<
 > = T extends (data: unknown, ...args: unknown[]) => data is infer R ? R : never
 
 /**
- * Use to skip validation, as it returns true for any input.
+ * Returns true for any input. Use to skip validation.
  * @param data
  */
 export const isUnknown = (data: unknown): data is unknown => true
@@ -27,6 +26,7 @@ export const isUnknown = (data: unknown): data is unknown => true
  */
 
 export const isNull = (data: unknown): data is null => data === null
+
 export const isUndefined = (data: unknown): data is undefined =>
   typeof data === 'undefined'
 
@@ -44,17 +44,6 @@ export const isBigInt = (data: unknown): data is bigint =>
 
 export const isSymbol = (data: unknown): data is symbol =>
   typeof data === 'symbol'
-
-// TODO unit tests
-export const isFunction = (data: unknown): data is Function =>
-  typeof data === 'function'
-
-// TODO unit tests
-export const isObject = (data: unknown): data is object =>
-  typeof data === 'object' && data !== null
-
-// TODO unit tests
-export const isArray: (data: unknown) => data is unknown[] = Array.isArray
 
 /*
  *
@@ -178,13 +167,6 @@ export const tuple =
     Array.isArray(data) &&
     data.length === validators.length &&
     validators.every((validator, index) => validator(data[index]))
-
-export type RequiredKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
-}[keyof T]
-export type OptionalKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? K : never
-}[keyof T]
 
 /**
  * Validate structs; records that map known keys to a specific type.

--- a/packages/pure-parse/src/validation.ts
+++ b/packages/pure-parse/src/validation.ts
@@ -2,6 +2,8 @@
  * Utility Types
  */
 
+import { hasKey } from './internals'
+
 /**
  * A function that return a [type predicate](https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates) on the argument.
  */
@@ -42,6 +44,17 @@ export const isBigInt = (data: unknown): data is bigint =>
 
 export const isSymbol = (data: unknown): data is symbol =>
   typeof data === 'symbol'
+
+// TODO unit tests
+export const isFunction = (data: unknown): data is Function =>
+  typeof data === 'function'
+
+// TODO unit tests
+export const isObject = (data: unknown): data is object =>
+  typeof data === 'object' && data !== null
+
+// TODO unit tests
+export const isArray: (data: unknown) => data is unknown[] = Array.isArray
 
 /*
  *
@@ -103,16 +116,16 @@ export const union =
     validators.some((validator) => validator(data))
 
 /**
- * Used to respresent optional validators at runtime and compile-time in two different ways
+ * Used to represent optional validators at runtime and compile-time in two different ways
  */
 const optionalSymbol = Symbol('optional')
 
 /**
  * Special validator to check optional values
  */
-type OptionalValidator<T> = { [optionalSymbol]: true } & ((
+export type OptionalValidator<T> = { [optionalSymbol]: true } & ((
   data: unknown,
-) => data is typeof optionalSymbol)
+) => data is typeof optionalSymbol | T | undefined)
 
 /**
  * Represent an optional property, which is different from a required property that can be `undefined`.
@@ -120,9 +133,7 @@ type OptionalValidator<T> = { [optionalSymbol]: true } & ((
  */
 export const optional = <T>(validator: Validator<T>): OptionalValidator<T> =>
   /*
-   * This function uses two tricks:
-   *  1. { [optionalValue]: true } is used at runtime by `object` to check if a validator represents an optional value.
-   *  2. The return type is a symbol so that it in generic conditional expressions, it does not overlap with Validator.
+   * { [optionalValue]: true } is used at runtime by `object` to check if a validator represents an optional value.
    */
   Object.assign(union(isUndefined, validator), {
     [optionalSymbol]: true,
@@ -168,6 +179,13 @@ export const tuple =
     data.length === validators.length &&
     validators.every((validator, index) => validator(data[index]))
 
+export type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T]
+export type OptionalKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never
+}[keyof T]
+
 /**
  * Validate structs; records that map known keys to a specific type.
  *
@@ -198,22 +216,14 @@ export const object =
         // TODO this shouldn't happen, as the type ensures that all properties are validators
         return false
       }
-      if (!(key in data)) {
+      if (!hasKey(data, key)) {
         // If the key is not present, the validator must represent an optional property
         return optionalSymbol in validator
       }
-      // @ts-ignore - we check that the key is present on the line above
       const value = data[key]
 
       return validator(value)
     })
-
-type RequiredKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
-}[keyof T]
-type OptionalKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? K : never
-}[keyof T]
 
 /**
  * Validate `Record<?, ?>`; objects that definitely map strings to another specific type.


### PR DESCRIPTION
## What?

Fix:

- optional validators still returns a type predicate on a symbol, but to improve the type inference for optional properties, include the type parameter `T` and `undefined`. https://github.com/johannes-lindgren/pure-parse/pull/19/files#diff-4468c9b0c3579469c574c072305c3a1f75b3d66d752b609300429f900bbbbd90R500-R524 

Various refactor:

- new unit tests that tests type inference for optional properties–it doesn't work, and I can't figure out a solution. So we document it.
- new test for optional properties: https://github.com/johannes-lindgren/pure-parse/pull/19/files#diff-4468c9b0c3579469c574c072305c3a1f75b3d66d752b609300429f900bbbbd90R859-R870
- Removed duplicate test `Infer`
- Created internal module `internals` for code that is used internally in the package.

## Why?

Reduce the size of #17, which introduces parsing.

