### PR TITLE
fix: Equals utility type

### DIFF
--- a/packages/pure-parse/src/internals/Equals.test.ts
+++ b/packages/pure-parse/src/internals/Equals.test.ts
@@ -1,5 +1,43 @@
-export type Equals<T1, T2> = T1 extends T2
-  ? T2 extends T1
-    ? true
-    : false
-  : false
+import { describe, it, test } from 'vitest'
+import { Equals } from './Equals'
+
+describe('Equals', () => {
+  test('primitives', () => {
+    const a1: Equals<string, string> = true
+    const a2: Equals<string, number> = false
+    const a3: Equals<null, undefined> = false
+  })
+  test('objects', () => {
+    const a1: Equals<{}, {}> = true
+    const a2: Equals<{ a: string }, { a: string }> = true
+    const a3: Equals<{ a: string }, { a: number }> = false
+    const a4: Equals<{ a: string }, {}> = false
+    const a5: Equals<{}, { a: string }> = false
+  })
+  test('tuples', () => {
+    const a0: Equals<[], []> = true
+    const a2: Equals<[number, number], [number, number]> = true
+    const a3: Equals<[number], [number, number]> = false
+    const a4: Equals<[number, number], [number]> = false
+  })
+  test('arrays', () => {
+    const a0: Equals<[], []> = true
+    const a1: Equals<string[], []> = false
+    const a2: Equals<(string | number)[], (string | number)[]> = true
+    const a3: Equals<(string | number)[], string[]> = false
+    const a4: Equals<string[], (string | number)[]> = false
+  })
+  test('never', () => {
+    const a1: Equals<never, never> = true
+    // @ts-expect-error
+    const a2: Equals<never, never> = false
+
+    const a3: Equals<string, never> = false
+    // @ts-expect-error
+    const a4: Equals<string, never> = true
+
+    const a5: Equals<never, string> = false
+    // @ts-expect-error
+    const a6: Equals<never, string> = true
+  })
+})

--- a/packages/pure-parse/src/internals/Equals.test.ts
+++ b/packages/pure-parse/src/internals/Equals.test.ts
@@ -1,0 +1,5 @@
+export type Equals<T1, T2> = T1 extends T2
+  ? T2 extends T1
+    ? true
+    : false
+  : false

--- a/packages/pure-parse/src/internals/Equals.ts
+++ b/packages/pure-parse/src/internals/Equals.ts
@@ -1,9 +1,30 @@
-/**
- * Check whether two types are equal. `true` if they are, `false` if not.
- * Useful for testing generics.
- */
-export type Equals<T1, T2> = T1 extends T2
-  ? T2 extends T1
-    ? true
-    : false
-  : false
+import { describe, it, test } from 'vitest'
+import { Equals } from './Equals.test'
+
+describe('Equals', () => {
+  test('primitives', () => {
+    const a1: Equals<string, string> = true
+    const a2: Equals<string, number> = false
+    const a3: Equals<null, undefined> = false
+  })
+  test('objects', () => {
+    const a1: Equals<{}, {}> = true
+    const a2: Equals<{ a: string }, { a: string }> = true
+    const a3: Equals<{ a: string }, { a: number }> = false
+    const a4: Equals<{ a: string }, {}> = false
+    const a5: Equals<{}, { a: string }> = false
+  })
+  test('tuples', () => {
+    const a0: Equals<[], []> = true
+    const a2: Equals<[number, number], [number, number]> = true
+    const a3: Equals<[number], [number, number]> = false
+    const a4: Equals<[number, number], [number]> = false
+  })
+  test('arrays', () => {
+    const a0: Equals<[], []> = true
+    const a1: Equals<string[], []> = false
+    const a2: Equals<(string | number)[], (string | number)[]> = true
+    const a3: Equals<(string | number)[], string[]> = false
+    const a4: Equals<string[], (string | number)[]> = false
+  })
+})

--- a/packages/pure-parse/src/internals/Equals.ts
+++ b/packages/pure-parse/src/internals/Equals.ts
@@ -1,30 +1,5 @@
-import { describe, it, test } from 'vitest'
-import { Equals } from './Equals.test'
-
-describe('Equals', () => {
-  test('primitives', () => {
-    const a1: Equals<string, string> = true
-    const a2: Equals<string, number> = false
-    const a3: Equals<null, undefined> = false
-  })
-  test('objects', () => {
-    const a1: Equals<{}, {}> = true
-    const a2: Equals<{ a: string }, { a: string }> = true
-    const a3: Equals<{ a: string }, { a: number }> = false
-    const a4: Equals<{ a: string }, {}> = false
-    const a5: Equals<{}, { a: string }> = false
-  })
-  test('tuples', () => {
-    const a0: Equals<[], []> = true
-    const a2: Equals<[number, number], [number, number]> = true
-    const a3: Equals<[number], [number, number]> = false
-    const a4: Equals<[number, number], [number]> = false
-  })
-  test('arrays', () => {
-    const a0: Equals<[], []> = true
-    const a1: Equals<string[], []> = false
-    const a2: Equals<(string | number)[], (string | number)[]> = true
-    const a3: Equals<(string | number)[], string[]> = false
-    const a4: Equals<string[], (string | number)[]> = false
-  })
-})
+export type Equals<T1, T2> = [T1] extends [T2]
+  ? [T2] extends [T1]
+    ? true
+    : false
+  : false

--- a/packages/pure-parse/src/internals/utility-types.test.ts
+++ b/packages/pure-parse/src/internals/utility-types.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, test } from 'vitest'
+import { Equals } from './Equals'
+import { OptionalKeys, RequiredKeys } from './utility-types'
+
+describe('RequiredKeys', () => {
+  it('gives the keys', () => {
+    const a1: Equals<RequiredKeys<{ a: 1 }>, 'a'> = true
+    const a2: Equals<RequiredKeys<{ a: 1; b: 1 }>, 'a' | 'b'> = true
+  })
+  it('handles empty objects', () => {
+    const a0: Equals<RequiredKeys<{}>, never> = true
+    // @ts-expect-error
+    const a1: Equals<RequiredKeys<{}>, never> = false
+  })
+  it('excludes optional keys', () => {
+    const a1: Equals<RequiredKeys<{ a: 1; b?: 1 }>, 'a'> = true
+    const a2: Equals<RequiredKeys<{ a: 1; b?: 1; c: 1 }>, 'a' | 'c'> = true
+  })
+})
+describe('OptionalKeys', () => {
+  it('gives the keys', () => {
+    const a1: Equals<OptionalKeys<{ a?: 1 }>, 'a'> = true
+    const a2: Equals<OptionalKeys<{ a?: 1; b?: 1 }>, 'a' | 'b'> = true
+  })
+  it('handles empty objects', () => {
+    const a0: Equals<OptionalKeys<{}>, never> = true
+    // @ts-expect-error
+    const a1: Equals<OptionalKeys<{}>, never> = false
+  })
+  it('excludes required keys', () => {
+    const a1: Equals<OptionalKeys<{ a?: 1; b: 1 }>, 'a'> = true
+    const a2: Equals<OptionalKeys<{ a?: 1; b: 1; c?: 1 }>, 'a' | 'c'> = true
+  })
+})


### PR DESCRIPTION
The `Equals` utility type doesn't work on type `never` since `never` short-circuits the conditional type. The solution is to wrap the type parameters inside tuples `[T1]` and `[T2]`.

Also add unit tests for the three utility types:

- `Equals`
- `OptionalKeys`
- `RequiredKeys`