### PR TITLE
refactor: replace isSuccess property on parse results with function

### DIFF
--- a/packages/pure-parse/src/parsing/array.test.ts
+++ b/packages/pure-parse/src/parsing/array.test.ts
@@ -9,7 +9,6 @@ describe('arrays', () => {
     const parseArr = array(literal('a'))
     expect(parseArr(['a', 'a'])).toEqual({
       tag: 'success',
-      isSuccess: true,
       value: ['a', 'a'],
     })
     expect(parseArr(['a', 'b'])).toHaveProperty('tag', 'failure')
@@ -18,22 +17,18 @@ describe('arrays', () => {
     const parseArr = array(fallback(literal('#FF0000'), '#00FF00'))
     expect(parseArr(['#FF0000', '#FF0000'])).toEqual({
       tag: 'success',
-      isSuccess: true,
       value: ['#FF0000', '#FF0000'],
     })
     expect(parseArr(['#FF0000', '#XXYYZZ'])).toEqual({
       tag: 'success',
-      isSuccess: true,
       value: ['#FF0000', '#00FF00'],
     })
     expect(parseArr(['#XXYYZZ', '#XXYYZZ'])).toEqual({
       tag: 'success',
-      isSuccess: true,
       value: ['#00FF00', '#00FF00'],
     })
     expect(parseArr(['#FF0000', '#XXYYZZ', '#FF0000', '#XXYYZZ'])).toEqual({
       tag: 'success',
-      isSuccess: true,
       value: ['#FF0000', '#00FF00', '#FF0000', '#00FF00'],
     })
   })

--- a/packages/pure-parse/src/parsing/array.ts
+++ b/packages/pure-parse/src/parsing/array.ts
@@ -1,5 +1,6 @@
 import {
   failure,
+  isSuccess,
   ParseSuccess,
   ParseSuccessFallback,
   RequiredParser,
@@ -11,7 +12,7 @@ import {
 const areAllSuccesses = <T>(
   results: RequiredParseResult<T>[],
 ): results is (ParseSuccess<T> | ParseSuccessFallback<T>)[] =>
-  results.every((result) => result.isSuccess)
+  results.every((result) => isSuccess(result))
 
 /**
  * Validate arrays

--- a/packages/pure-parse/src/parsing/object.test.ts
+++ b/packages/pure-parse/src/parsing/object.test.ts
@@ -181,7 +181,6 @@ describe('objects', () => {
       // The email can be a omitted -> Success
       expect(parseUser({ id: 1, name: 'Alice' })).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: { id: 1, name: 'Alice' },
       })
 
@@ -190,14 +189,12 @@ describe('objects', () => {
         parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
       ).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: { id: 1, name: 'Alice', email: 'alice@test.com' },
       })
 
       // The email can't be a number -> falls back
       expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: { id: 1, name: 'Alice', email: defaultEmail },
       })
     })
@@ -214,14 +211,12 @@ describe('objects', () => {
         parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
       ).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: { id: 1, name: 'Alice', email: 'alice@test.com' },
       })
 
       // number fails -> Falls back
       expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: { id: 1, name: 'Alice', email: defaultEmail },
       })
 

--- a/packages/pure-parse/src/parsing/parse.test.ts
+++ b/packages/pure-parse/src/parsing/parse.test.ts
@@ -71,7 +71,6 @@ describe('parsing', () => {
       }
       expect(parseDocument(data)).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: {
           title: data.title,
           content: [

--- a/packages/pure-parse/src/parsing/parse.ts
+++ b/packages/pure-parse/src/parsing/parse.ts
@@ -5,8 +5,6 @@ import { optionalSymbol } from './optionalSymbol'
  */
 export type ParseSuccess<T> = {
   tag: 'success'
-  // TODO remove isSuccess
-  isSuccess: true
   value: T
 }
 
@@ -15,7 +13,6 @@ export type ParseSuccess<T> = {
  */
 export type ParseSuccessFallback<T> = {
   tag: 'success-fallback'
-  isSuccess: true
   value: T
 }
 
@@ -24,7 +21,6 @@ export type ParseSuccessFallback<T> = {
  */
 export type ParseSuccessPropAbsent = {
   tag: 'success-prop-absent'
-  isSuccess: true
 }
 
 /**
@@ -32,7 +28,6 @@ export type ParseSuccessPropAbsent = {
  */
 export type ParseFailure = {
   tag: 'failure'
-  isSuccess: false
   error: string
 }
 
@@ -51,24 +46,20 @@ export type OptionalParseResult<T> = ParseResult<T>
 
 export const success = <T>(value: T): ParseSuccess<T> => ({
   tag: 'success',
-  isSuccess: true,
   value,
 })
 
 export const successFallback = <T>(value: T): ParseSuccessFallback<T> => ({
   tag: 'success-fallback',
-  isSuccess: true,
   value,
 })
 
 export const successOptional = (): ParseSuccessPropAbsent => ({
   tag: 'success-prop-absent',
-  isSuccess: true,
 })
 
 export const failure = (error: string): ParseFailure => ({
   tag: 'failure',
-  isSuccess: false,
   error,
 })
 
@@ -119,3 +110,13 @@ export const fallback =
  */
 export const parseUnknown = (data: unknown): ParseSuccess<unknown> =>
   success(data)
+
+export const isSuccess = <T>(
+  result: ParseResult<T>,
+): result is
+  | ParseSuccess<T>
+  | ParseSuccessFallback<T>
+  | ParseSuccessPropAbsent =>
+  result.tag === 'success' ||
+  result.tag === 'success-fallback' ||
+  result.tag === 'success-prop-absent'

--- a/packages/pure-parse/src/parsing/primitives.test.ts
+++ b/packages/pure-parse/src/parsing/primitives.test.ts
@@ -15,7 +15,6 @@ describe('primitives', () => {
       const parseLiteral = literal('a')
       expect(parseLiteral('a')).toEqual({
         tag: 'success',
-        isSuccess: true,
         value: 'a',
       })
     })
@@ -23,7 +22,6 @@ describe('primitives', () => {
       const parseLiteral = fallback(literal('#FF0000'), '#00FF00')
       expect(parseLiteral('#XXYYZZ')).toEqual({
         tag: 'success-fallback',
-        isSuccess: true,
         value: '#00FF00',
       })
     })


### PR DESCRIPTION
## What?

Replace isSuccess property on parse results with function.

The data doesn't need  the `isSuccess` property:

```ts
export type ParseSuccess<T> = {
  tag: 'success'
  isSuccess
  value: T
}
```

the tag already conveys this information.

Therefore, introduce a function that checks the property instead
