### PR TITLE
feat: referential preservation

### DIFF
--- a/packages/pure-parse/src/parsing/array.test.ts
+++ b/packages/pure-parse/src/parsing/array.test.ts
@@ -1,36 +1,44 @@
 import { describe, expect, it, test } from 'vitest'
 import { array } from './array'
-import { failure, fallback, success, successFallback } from './parse'
+import { failure, success, successFallback } from './parse'
 
-import { literal, parseString } from './primitives'
+import { literal, parseNumber, parseString } from './primitives'
+import { fallback } from './fallback'
 
 describe('arrays', () => {
-  it('todo', () => {
+  it('validates when all elements pass validation', () => {
     const parseArr = array(literal('a'))
     expect(parseArr(['a', 'a'])).toEqual({
       tag: 'success',
       value: ['a', 'a'],
     })
+  })
+  it('invalidates when any elements pass validation', () => {
+    const parseArr = array(literal('a'))
     expect(parseArr(['a', 'b'])).toHaveProperty('tag', 'failure')
   })
   test('with fallback', () => {
     const parseArr = array(fallback(literal('#FF0000'), '#00FF00'))
-    expect(parseArr(['#FF0000', '#FF0000'])).toEqual({
-      tag: 'success',
-      value: ['#FF0000', '#FF0000'],
-    })
-    expect(parseArr(['#FF0000', '#XXYYZZ'])).toEqual({
-      tag: 'success',
-      value: ['#FF0000', '#00FF00'],
-    })
-    expect(parseArr(['#XXYYZZ', '#XXYYZZ'])).toEqual({
-      tag: 'success',
-      value: ['#00FF00', '#00FF00'],
-    })
-    expect(parseArr(['#FF0000', '#XXYYZZ', '#FF0000', '#XXYYZZ'])).toEqual({
-      tag: 'success',
-      value: ['#FF0000', '#00FF00', '#FF0000', '#00FF00'],
-    })
+    expect(parseArr(['#FF0000', '#FF0000'])).toEqual(
+      expect.objectContaining({
+        value: ['#FF0000', '#FF0000'],
+      }),
+    )
+    expect(parseArr(['#FF0000', '#XXYYZZ'])).toEqual(
+      expect.objectContaining({
+        value: ['#FF0000', '#00FF00'],
+      }),
+    )
+    expect(parseArr(['#XXYYZZ', '#XXYYZZ'])).toEqual(
+      expect.objectContaining({
+        value: ['#00FF00', '#00FF00'],
+      }),
+    )
+    expect(parseArr(['#FF0000', '#XXYYZZ', '#FF0000', '#XXYYZZ'])).toEqual(
+      expect.objectContaining({
+        value: ['#FF0000', '#00FF00', '#FF0000', '#00FF00'],
+      }),
+    )
   })
   test('that the result type is infallible', () => {
     const res = fallback(parseString, '')(123)
@@ -39,5 +47,57 @@ describe('arrays', () => {
     // @ts-expect-error -- fallback result is infallible
     const a3: typeof res = failure('')
   })
-  describe.todo('referential preservation')
+  describe('referential preservation', () => {
+    describe('shallow arrays', () => {
+      it('should return the same reference when elements pass validation', () => {
+        const parseStr = array(parseNumber)
+        const arr = [1, 2, 3, 4]
+        const res = parseStr(arr)
+        if (res.tag === 'failure') {
+          throw new Error('Expected success')
+        }
+        expect(res.value).toBe(arr)
+      })
+      it('should return the same reference when elements fail validation', () => {
+        const parseStr = array(fallback(parseNumber, 0))
+        const arr = [1, 2, '3', 4]
+        const res = parseStr(arr)
+        if (res.tag === 'failure') {
+          throw new Error('Expected success')
+        }
+        expect(res.value).not.toBe(arr)
+      })
+    })
+    describe('deep arrays', () => {
+      it('should return the same reference when nested elements pass validation', () => {
+        const parseStr = array(array(parseNumber))
+        const arr = [
+          [1, 2],
+          [3, 4],
+        ]
+        const res = parseStr(arr)
+        if (res.tag === 'failure') {
+          throw new Error('Expected success')
+        }
+        expect(res.value).toBe(arr)
+        expect(res.value[0]).toBe(arr[0])
+        expect(res.value[1]).toBe(arr[1])
+      })
+      it('should return a new reference when nested elements fail validation', () => {
+        const parseStr = array(array(fallback(parseNumber, 0)))
+        const arr = [
+          [1, 2],
+          [3, '4'],
+        ]
+        const res = parseStr(arr)
+        if (res.tag === 'failure') {
+          throw new Error('Expected success')
+        }
+        expect(res.value).not.toBe(arr)
+        expect(res.value[0]).toBe(arr[0])
+        expect(res.value[1]).not.toBe(arr[1])
+      })
+    })
+  })
+  describe.todo('self-referential arrays')
 })

--- a/packages/pure-parse/src/parsing/array.ts
+++ b/packages/pure-parse/src/parsing/array.ts
@@ -1,11 +1,13 @@
 import {
   failure,
   isSuccess,
+  ParseResult,
   ParseSuccess,
   ParseSuccessFallback,
   RequiredParser,
   RequiredParseResult,
   success,
+  successFallback,
 } from './parse'
 
 // Local helper function
@@ -26,9 +28,27 @@ export const array =
       return failure('Not an array')
     }
     const results: RequiredParseResult<T>[] = data.map(parseItem)
-    if (!areAllSuccesses(results)) {
-      return failure('Not all items in the array are valid')
+
+    // Imperative programming for performance
+    let allSuccess = true
+    let allOriginal = true
+    for (const result of results) {
+      allSuccess &&= result.tag !== 'failure'
+      allOriginal &&= result.tag === 'success'
     }
-    // TODO if all were non-fallbacks, return the same array
-    return success(results.map((result) => result.value))
+
+    if (allOriginal) {
+      // Preserve reference equality if no properties were falling back to defaults
+      return success(data as T[])
+    }
+    if (!allSuccess) {
+      return failure('Not all elements are valid')
+    }
+
+    // If any element is a fallback, return a new array
+    return successFallback(
+      (
+        results as Array<Exclude<RequiredParseResult<T>, { tag: 'failure' }>>
+      ).map((result) => result.value),
+    )
   }

--- a/packages/pure-parse/src/parsing/fallback.test.ts
+++ b/packages/pure-parse/src/parsing/fallback.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, test } from 'vitest'
+import { fallback } from './fallback'
+import { parseString } from './primitives'
+import { object } from './object'
+
+describe('fallback', () => {
+  test('as a root parser', () => {
+    const parseStr = fallback(parseString, 'fallback')
+    expect(parseStr('hello')).toEqual(
+      expect.objectContaining({
+        value: 'hello',
+      }),
+    )
+    expect(parseStr(123)).toEqual(
+      expect.objectContaining({
+        value: 'fallback',
+      }),
+    )
+  })
+  test('as a nested parser', () => {
+    const parseObj = object({
+      name: fallback(parseString, 'fallback'),
+    })
+    expect(parseObj({ name: 'hello' })).toEqual(
+      expect.objectContaining({
+        value: { name: 'hello' },
+      }),
+    )
+  })
+  describe('referential preservation', () => {
+    test('parsing success, where the reference is preserves', () => {
+      const parseStr = fallback(parseString, 'fallback')
+      expect(parseStr('hello')).toHaveProperty('tag', 'success')
+    })
+    test('parsing failure with fallback, where the reference is preserves', () => {
+      const parseStr = fallback(parseString, 'fallback')
+      expect(parseStr(123)).toHaveProperty('tag', 'success-fallback')
+    })
+  })
+  describe('fallback on fallback', () => {
+    it('uses the first fallback', () => {
+      const parseStr = fallback(fallback(parseString, 'fallback'), 'fallback2')
+      expect(parseStr('hello')).toEqual(
+        expect.objectContaining({
+          value: 'hello',
+        }),
+      )
+      expect(parseStr(123)).toEqual(
+        expect.objectContaining({
+          value: 'fallback',
+        }),
+      )
+    })
+  })
+  test.todo('on optional properties')
+})

--- a/packages/pure-parse/src/parsing/fallback.ts
+++ b/packages/pure-parse/src/parsing/fallback.ts
@@ -1,0 +1,21 @@
+import { InfallibleParser, RequiredParser, successFallback } from './parse'
+
+/**
+ * Use to provide a default value when parsing fails.
+ * @param parser
+ * @param defaultValue
+ */
+export const fallback =
+  <T, F>(parser: RequiredParser<T>, defaultValue: F): InfallibleParser<T | F> =>
+  (data: unknown) => {
+    const result = parser(data)
+    switch (result.tag) {
+      case 'failure':
+        return successFallback(defaultValue)
+      case 'success-fallback':
+        return result
+      // Success
+      default:
+        return result
+    }
+  }

--- a/packages/pure-parse/src/parsing/index.ts
+++ b/packages/pure-parse/src/parsing/index.ts
@@ -3,4 +3,5 @@ export * from './array'
 export * from './object'
 export * from './union'
 export * from './primitives'
+export * from './fallback'
 // Do not export optionalSymbol

--- a/packages/pure-parse/src/parsing/object.test.ts
+++ b/packages/pure-parse/src/parsing/object.test.ts
@@ -232,5 +232,95 @@ describe('objects', () => {
       )
     })
   })
-  describe.todo('referential preservation')
+  describe('referential preservation', () => {
+    describe('shallow object', () => {
+      it('preserves reference when all properties are success', () => {
+        const parseUser = object({
+          id: parseNumber,
+          name: parseString,
+        })
+        const user = { id: 1, name: 'Alice' }
+        const result = parseUser(user)
+        if (result.tag === 'success') {
+          expect(result.value).toBe(user)
+        } else {
+          throw new Error('Expected success')
+        }
+      })
+      it('preserves reference when a property is optional', () => {
+        type User = {
+          id: number
+          name?: string
+        }
+        const parseUser = object<User>({
+          id: parseNumber,
+          name: optional(parseString),
+        })
+        const user = { id: 1, name: 'Alice' }
+        const result = parseUser(user)
+        if (result.tag === 'success') {
+          expect(result.value).toBe(user)
+        } else {
+          throw new Error('Expected success')
+        }
+      })
+      it('does not preserve reference when a property is fallback', () => {
+        const parseUser = object({
+          id: parseNumber,
+          name: fallback(parseString, 'Anonymous'),
+        })
+        const user = { id: 1, name: 123 }
+        const result = parseUser(user)
+        if (result.tag === 'success') {
+          expect(result.value).not.toBe(user)
+        } else {
+          throw new Error('Expected success')
+        }
+      })
+    })
+    describe('nested object', () => {
+      it('preserves reference when all properties are success', () => {
+        const parseUser = object({
+          id: parseNumber,
+          name: parseString,
+          address: object({
+            street: parseString,
+            city: parseString,
+          }),
+        })
+        const user = {
+          id: 1,
+          name: 'Alice',
+          address: { street: '1st', city: 'NY' },
+        }
+        const result = parseUser(user)
+        if (result.tag === 'success') {
+          expect(result.value).toBe(user)
+        } else {
+          throw new Error('Expected success')
+        }
+      })
+      it('does not preserve reference when a nested property fallback', () => {
+        const parseUser = object({
+          id: parseNumber,
+          name: parseString,
+          address: object({
+            street: parseString,
+            city: fallback(parseString, 'NY'),
+          }),
+        })
+        const user = {
+          id: 1,
+          name: 'Alice',
+          address: { street: '1st', city: 123 },
+        }
+        const result = parseUser(user)
+        if (result.tag === 'success-fallback') {
+          expect(result.value).not.toBe(user)
+        } else {
+          throw new Error('Expected success')
+        }
+      })
+    })
+  })
 })

--- a/packages/pure-parse/src/parsing/object.test.ts
+++ b/packages/pure-parse/src/parsing/object.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, test } from 'vitest'
 import { object } from './object'
-import { fallback, Infer, isSuccess } from './parse'
+import { Infer, isSuccess } from './parse'
 import type { Equals } from '../internals'
 import { nullable, optional } from './union'
 import { parseNumber, parseString } from './primitives'
+import { fallback } from './fallback'
 
 describe('objects', () => {
   describe('required properties', () => {
@@ -323,4 +324,5 @@ describe('objects', () => {
       })
     })
   })
+  describe.todo('self-referential objects')
 })

--- a/packages/pure-parse/src/parsing/object.ts
+++ b/packages/pure-parse/src/parsing/object.ts
@@ -61,17 +61,14 @@ export const object =
       const value = data[key]
       return [key, parser(value)] as [string, ParseResult<unknown>]
     })
-    const { allSuccess, allOriginal } = results.reduce(
-      (acc, [_, result]) => {
-        acc.allSuccess &&= result.tag !== 'failure'
-        acc.allOriginal &&= result.tag === 'success'
-        return acc
-      },
-      {
-        allSuccess: true,
-        allOriginal: true,
-      },
-    )
+    // Imperative programming for performance
+    let allSuccess = true
+    let allOriginal = true
+    for (const [_, result] of results) {
+      allSuccess &&= result.tag !== 'failure'
+      allOriginal &&= result.tag === 'success'
+    }
+
     if (allOriginal) {
       // Preserve reference equality if no properties were falling back to defaults
       return success(data as T)

--- a/packages/pure-parse/src/parsing/object.ts
+++ b/packages/pure-parse/src/parsing/object.ts
@@ -81,7 +81,11 @@ export const object =
     }
     return successFallback(
       Object.fromEntries(
-        results
+        (
+          results as Array<
+            [string, Exclude<ParseResult<T>, { tag: 'failure' }>]
+          >
+        )
           .filter(wasPropPresent)
           .map(([key, result]) => [key, result.value]),
       ),

--- a/packages/pure-parse/src/parsing/object.ts
+++ b/packages/pure-parse/src/parsing/object.ts
@@ -80,7 +80,6 @@ export const object =
       return failure('Not all properties are valid')
     }
     return successFallback(
-      // TODO if none of the successes were fallbacks, we can just return data as is, thus preserving equality
       Object.fromEntries(
         results
           .filter(wasPropPresent)

--- a/packages/pure-parse/src/parsing/object.ts
+++ b/packages/pure-parse/src/parsing/object.ts
@@ -42,9 +42,6 @@ const analyze = <T>(
     if (result.tag === 'failure') {
       return { tag: 'failure' }
     }
-    if (result.tag === 'success') {
-      allOriginal = false
-    }
     if (result.tag === 'success-fallback') {
       allOriginal = false
     }

--- a/packages/pure-parse/src/parsing/parse.test.ts
+++ b/packages/pure-parse/src/parsing/parse.test.ts
@@ -69,18 +69,19 @@ describe('parsing', () => {
           { tag: 'number', value: 3 },
         ],
       }
-      expect(parseDocument(data)).toEqual({
-        tag: 'success',
-        value: {
-          title: data.title,
-          content: [
-            { tag: 'string', value: 'day 1' },
-            // Fallback in place
-            { tag: 'unknown' },
-            { tag: 'number', value: 3 },
-          ],
-        },
-      })
+      expect(parseDocument(data)).toEqual(
+        expect.objectContaining({
+          value: {
+            title: data.title,
+            content: [
+              { tag: 'string', value: 'day 1' },
+              // Fallback in place
+              { tag: 'unknown' },
+              { tag: 'number', value: 3 },
+            ],
+          },
+        }),
+      )
     })
   })
   describe.todo('recursive types')

--- a/packages/pure-parse/src/parsing/parse.test.ts
+++ b/packages/pure-parse/src/parsing/parse.test.ts
@@ -1,18 +1,11 @@
 import { describe, expect, it, test } from 'vitest'
-import { fallback } from './parse'
 import { array } from './array'
 import { object } from './object'
 import { optional, union } from './union'
 import { literal, parseNumber, parseString } from './primitives'
+import { fallback } from './fallback'
 
 describe('parsing', () => {
-  describe('fallback', () => {
-    test.todo('on success')
-    test.todo('on validation failure')
-    test.todo('on fallback')
-    test.todo('on optional properties')
-    test.todo('fallback on fallback')
-  })
   describe('some use cases', () => {
     test('parsing objects in an array with fallback', () => {
       /*
@@ -84,5 +77,4 @@ describe('parsing', () => {
       )
     })
   })
-  describe.todo('recursive types')
 })

--- a/packages/pure-parse/src/parsing/parse.ts
+++ b/packages/pure-parse/src/parsing/parse.ts
@@ -94,16 +94,6 @@ export type Infer<T extends Parser<unknown>> = T extends Parser<infer D>
  * Utility functions
  */
 
-export const fallback =
-  <T, F>(parser: Parser<T>, defaultValue: F): InfallibleParser<T | F> =>
-  (data: unknown): ParseSuccess<T> | ParseSuccessFallback<F> => {
-    const result = parser(data)
-    if (result.tag !== 'success') {
-      return successFallback(defaultValue)
-    }
-    return result
-  }
-
 /**
  * Use to skip validation, as it returns true for any input.
  * @param data

--- a/packages/pure-parse/src/parsing/primitives.test.ts
+++ b/packages/pure-parse/src/parsing/primitives.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from 'vitest'
 import { literal } from './primitives'
-import { fallback } from './parse'
+import { fallback } from './fallback'
 
 describe('primitives', () => {
   describe.todo('null')

--- a/packages/pure-parse/src/parsing/union.test.ts
+++ b/packages/pure-parse/src/parsing/union.test.ts
@@ -1,9 +1,140 @@
-import { describe } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { literal, parseNumber, parseString } from './primitives'
+import {
+  nullable,
+  optional,
+  optionalNullable,
+  undefineable,
+  union,
+} from './union'
+import { fallback } from './parse'
+import { object } from './object'
 
 describe('unions', () => {
-  describe.todo('union')
-  describe.todo('optional')
-  describe.todo('nullable')
-  describe.todo('undefinable')
-  describe.todo('optionalNullable')
+  describe('union', () => {
+    describe('referential preservation', () => {
+      it('should return the same reference', () => {
+        const isNumberContent = object({
+          type: literal('number'),
+          value: parseNumber,
+        })
+        const isStringContent = object({
+          type: literal('string'),
+          value: parseString,
+        })
+        const parseContent = union(isNumberContent, isStringContent)
+
+        /*
+         Test first argument of union
+         */
+        const numberContent = {
+          type: 'number',
+          value: 123,
+        }
+        const resultNumber = parseContent(numberContent)
+        if (resultNumber.tag !== 'success') {
+          throw new Error('Expected success')
+        }
+        expect(resultNumber.value).toBe(numberContent)
+
+        /*
+         Test second argument of union
+         */
+        const stringContent = {
+          type: 'string',
+          value: 'hello',
+        }
+        const resultString = parseContent(stringContent)
+        if (resultString.tag !== 'success') {
+          throw new Error('Expected success')
+        }
+        expect(resultString.value).toBe(stringContent)
+      })
+    })
+  })
+  describe('optional', () => {
+    it('works with fallbacks', () => {
+      const parseName = optional(fallback(parseString, 'anonymous'))
+      expect(parseName('Johannes')).toEqual(
+        expect.objectContaining({
+          value: 'Johannes',
+        }),
+      )
+      expect(parseName(undefined)).toEqual(
+        expect.objectContaining({
+          value: undefined,
+        }),
+      )
+      expect(parseName(123)).toEqual(
+        expect.objectContaining({
+          value: 'anonymous',
+        }),
+      )
+    })
+  })
+  describe('nullable', () => {
+    it('works with fallbacks', () => {
+      const parseName = nullable(fallback(parseString, 'anonymous'))
+      expect(parseName('Johannes')).toEqual(
+        expect.objectContaining({
+          value: 'Johannes',
+        }),
+      )
+      expect(parseName(null)).toEqual(
+        expect.objectContaining({
+          value: null,
+        }),
+      )
+      expect(parseName(123)).toEqual(
+        expect.objectContaining({
+          value: 'anonymous',
+        }),
+      )
+    })
+  })
+  describe('undefinable', () => {
+    it('works with fallbacks', () => {
+      const parseName = undefineable(fallback(parseString, 'anonymous'))
+      expect(parseName('Johannes')).toEqual(
+        expect.objectContaining({
+          value: 'Johannes',
+        }),
+      )
+      expect(parseName(undefined)).toEqual(
+        expect.objectContaining({
+          value: undefined,
+        }),
+      )
+      expect(parseName(123)).toEqual(
+        expect.objectContaining({
+          value: 'anonymous',
+        }),
+      )
+    })
+  })
+  describe('optionalNullable', () => {
+    it('works with fallbacks', () => {
+      const parseName = optionalNullable(fallback(parseString, 'anonymous'))
+      expect(parseName('Johannes')).toEqual(
+        expect.objectContaining({
+          value: 'Johannes',
+        }),
+      )
+      expect(parseName(null)).toEqual(
+        expect.objectContaining({
+          value: null,
+        }),
+      )
+      expect(parseName(undefined)).toEqual(
+        expect.objectContaining({
+          value: undefined,
+        }),
+      )
+      expect(parseName(123)).toEqual(
+        expect.objectContaining({
+          value: 'anonymous',
+        }),
+      )
+    })
+  })
 })

--- a/packages/pure-parse/src/parsing/union.test.ts
+++ b/packages/pure-parse/src/parsing/union.test.ts
@@ -7,8 +7,8 @@ import {
   undefineable,
   union,
 } from './union'
-import { fallback } from './parse'
 import { object } from './object'
+import { fallback } from './fallback'
 
 describe('unions', () => {
   describe('union', () => {

--- a/packages/pure-parse/src/parsing/union.ts
+++ b/packages/pure-parse/src/parsing/union.ts
@@ -4,8 +4,10 @@ import {
   OptionalParser,
   ParseFailure,
   ParseSuccess,
+  ParseSuccessFallback,
   RequiredParser,
   success,
+  successFallback,
 } from './parse'
 import { parseNull, parseUndefined } from './primitives'
 
@@ -24,11 +26,19 @@ export const union =
       [K in keyof T]: RequiredParser<T[K]>
     }
   ) =>
-  (data: unknown): ParseSuccess<T[number]> | ParseFailure => {
+  (
+    data: unknown,
+  ):
+    | ParseSuccess<T[number]>
+    | ParseSuccessFallback<T[number]>
+    | ParseFailure => {
     for (const parser of parsers) {
       const result = parser(data)
-      if (result.tag !== 'failure') {
+      if (result.tag === 'success') {
         return success(result.value)
+      }
+      if (result.tag === 'success-fallback') {
+        return successFallback(result.value)
       }
     }
     return failure('No parser in the union matched')


### PR DESCRIPTION
## What?

When a value is successfully being parsed, one of two things can happen:

- validation succeeds
- validation fails, but a fallback is returned 

If the validation succeeds, we should always return the original value. However, this hasn't been the case for product (objects) and recursive types (arrays) because those were constructed with `.map()`.

The rule is this: if all properties/entries were successfully parsed, and if all the values in those results were preserved, then also preserve the value when returning.

These functions needed to be adjusted:

- `union`
- `object`
- `array`
- `fallback`

I.e. pretty much any higher order function. (The `nullable`, `optional` (etc) are just aliases of `union`, so did not need adjustments.)

Since `fallback()` plays a significant role, I also extracted this function into its own module, added tests, and fixed a bug (two fallbacks on top of each other). 

## Why?

Preserving the reference is important when working with immutable libraries, such as React, as this will allow you to utilize memoization. 

