### PR TITLE
fix: prototype pollution and unknown keys

### DIFF
--- a/packages/pure-parse/src/parsing/object.test.ts
+++ b/packages/pure-parse/src/parsing/object.test.ts
@@ -6,6 +6,17 @@ import { nullable, optional } from './union'
 import { parseNumber, parseString } from './primitives'
 
 describe('objects', () => {
+  describe('unknown properties', () => {
+    it('allows unknown properties', () => {
+      const parseObj = object({})
+      const data = { a: 'unexpected!' }
+      expect(parseObj(data)).toEqual(
+        expect.objectContaining({
+          value: data,
+        }),
+      )
+    })
+  })
   describe('required properties', () => {
     test('parsing', () => {
       const parseUser = object({
@@ -197,6 +208,20 @@ describe('objects', () => {
         tag: 'success',
         value: { id: 1, name: 'Alice', email: defaultEmail },
       })
+    })
+    it('includes unknown properties', () => {
+      const parseUser = object({
+        id: parseNumber,
+      })
+      const data = {
+        id: 123,
+        unknownProp: 'unexpected!',
+      }
+      expect(parseUser(data)).toEqual(
+        expect.objectContaining({
+          value: data,
+        }),
+      )
     })
     test('required fallback', () => {
       const defaultEmail = 'default@test.com'

--- a/packages/pure-parse/src/parsing/object.ts
+++ b/packages/pure-parse/src/parsing/object.ts
@@ -69,12 +69,12 @@ export const object =
       allOriginal &&= result.tag === 'success'
     }
 
-    if (allOriginal) {
-      // Preserve reference equality if no properties were falling back to defaults
-      return success(data as T)
-    }
     if (!allSuccess) {
       return failure('Not all properties are valid')
+    }
+    if (allOriginal && results.length === Object.keys(data).length) {
+      // Preserve reference equality if no properties were falling back to defaults
+      return success(data as T)
     }
     return successFallback(
       Object.fromEntries(


### PR DESCRIPTION
Fixes #38, #40

When an `object` parser encounters undeclared key, the key is omitted.

This also defends agains prototype pollution. 