### PR TITLE
feat!: removed required parser

### DIFF
--- a/packages/pure-parse/src/parse/array.ts
+++ b/packages/pure-parse/src/parse/array.ts
@@ -2,14 +2,14 @@ import {
   failure,
   isSuccess,
   ParseSuccess,
-  RequiredParser,
-  RequiredParseResult,
+  Parser,
+  ParseResult,
   success,
 } from './parse'
 
 // Local helper function
 const areAllSuccesses = <T>(
-  results: RequiredParseResult<T>[],
+  results: ParseResult<T>[],
 ): results is ParseSuccess<T>[] => results.every((result) => isSuccess(result))
 
 /**
@@ -18,12 +18,12 @@ const areAllSuccesses = <T>(
  * @param parseItem
  */
 export const array =
-  <T>(parseItem: RequiredParser<T>): RequiredParser<T[]> =>
+  <T>(parseItem: Parser<T>): Parser<T[]> =>
   (data: unknown) => {
     if (!Array.isArray(data)) {
       return failure('Not an array')
     }
-    const results: RequiredParseResult<T>[] = data.map(parseItem)
+    const results: ParseResult<T>[] = data.map(parseItem)
 
     // Imperative programming for performance
     let allSuccess = true
@@ -37,8 +37,8 @@ export const array =
 
     // If any element is a fallback, return a new array
     return success(
-      (
-        results as Array<Exclude<RequiredParseResult<T>, { tag: 'failure' }>>
-      ).map((result) => result.value),
+      (results as Array<Exclude<ParseResult<T>, { tag: 'failure' }>>).map(
+        (result) => result.value,
+      ),
     )
   }

--- a/packages/pure-parse/src/parse/fallback.ts
+++ b/packages/pure-parse/src/parse/fallback.ts
@@ -1,4 +1,4 @@
-import { InfallibleParser, RequiredParser, success } from './parse'
+import { InfallibleParser, Parser, success } from './parse'
 
 /**
  * Use to provide a default value when parsing fails.
@@ -6,7 +6,7 @@ import { InfallibleParser, RequiredParser, success } from './parse'
  * @param defaultValue
  */
 export const fallback =
-  <T, F>(parser: RequiredParser<T>, defaultValue: F): InfallibleParser<T | F> =>
+  <T, F>(parser: Parser<T>, defaultValue: F): InfallibleParser<T | F> =>
   (data: unknown) => {
     const result = parser(data)
     switch (result.tag) {

--- a/packages/pure-parse/src/parse/object.ts
+++ b/packages/pure-parse/src/parse/object.ts
@@ -3,8 +3,8 @@ import {
   failure,
   OptionalParser,
   ParseSuccess,
-  RequiredParser,
-  RequiredParseResult,
+  Parser,
+  ParseResult,
   success,
 } from './parse'
 import { optionalSymbol } from './optionalSymbol'
@@ -27,9 +27,9 @@ export const object =
     // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
     [K in keyof T]-?: {} extends Pick<T, K>
       ? OptionalParser<T[K]>
-      : RequiredParser<T[K]>
+      : Parser<T[K]>
   }) =>
-  (data: unknown): RequiredParseResult<T> => {
+  (data: unknown): ParseResult<T> => {
     if (!isObject(data)) {
       return failure('Not an object')
     }
@@ -53,5 +53,5 @@ export const object =
       dataOutput[key] = (parseResult as ParseSuccess<unknown>).value
     }
 
-    return success(dataOutput) as RequiredParseResult<T>
+    return success(dataOutput) as ParseResult<T>
   }

--- a/packages/pure-parse/src/parse/parse.ts
+++ b/packages/pure-parse/src/parse/parse.ts
@@ -61,3 +61,6 @@ export const parseUnknown = (data: unknown): ParseSuccess<unknown> =>
 export const isSuccess = <T>(
   result: ParseResult<T>,
 ): result is ParseSuccess<T> => result.tag === 'success'
+
+export const isFailure = <T>(result: ParseResult<T>): result is ParseFailure =>
+  result.tag === 'failure'

--- a/packages/pure-parse/src/parse/parse.ts
+++ b/packages/pure-parse/src/parse/parse.ts
@@ -18,8 +18,6 @@ export type ParseFailure = {
 
 export type ParseResult<T> = ParseSuccess<T> | ParseFailure
 
-export type RequiredParseResult<T> = ParseSuccess<T> | ParseFailure
-
 export type OptionalParseResult<T> = ParseResult<T>
 
 export const success = <T>(value: T): ParseSuccess<T> => ({
@@ -33,8 +31,6 @@ export const failure = (error: string): ParseFailure => ({
 })
 
 export type Parser<T> = (data: unknown) => ParseResult<T>
-
-export type RequiredParser<T> = (data: unknown) => RequiredParseResult<T>
 
 /**
  * Special validator to check optional values

--- a/packages/pure-parse/src/parse/parse.ts
+++ b/packages/pure-parse/src/parse/parse.ts
@@ -18,8 +18,6 @@ export type ParseFailure = {
 
 export type ParseResult<T> = ParseSuccess<T> | ParseFailure
 
-export type OptionalParseResult<T> = ParseResult<T>
-
 export const success = <T>(value: T): ParseSuccess<T> => ({
   tag: 'success',
   value,
@@ -32,18 +30,14 @@ export const failure = (error: string): ParseFailure => ({
 
 export type Parser<T> = (data: unknown) => ParseResult<T>
 
+export type InfallibleParser<T> = (data: unknown) => ParseSuccess<T>
+
 /**
  * Special validator to check optional values
  */
 export type OptionalParser<T> = {
   [optionalSymbol]?: true
-} & ((data: unknown) => OptionalParseResult<T | undefined>)
-
-export type InfallibleParser<T> = (data: unknown) => ParseSuccess<T>
-
-export type FallibleParser<T> = (
-  data: unknown,
-) => ParseSuccess<T> | ParseFailure
+} & ((data: unknown) => ParseResult<T | undefined>)
 
 /*
  * Utility types

--- a/packages/pure-parse/src/parse/union.ts
+++ b/packages/pure-parse/src/parse/union.ts
@@ -4,7 +4,7 @@ import {
   OptionalParser,
   ParseFailure,
   ParseSuccess,
-  RequiredParser,
+  Parser,
   success,
 } from './parse'
 import { parseNull, parseUndefined } from './primitives'
@@ -21,7 +21,7 @@ import { parseNull, parseUndefined } from './primitives'
 export const union =
   <T extends readonly [...unknown[]]>(
     ...parsers: {
-      [K in keyof T]: RequiredParser<T[K]>
+      [K in keyof T]: Parser<T[K]>
     }
   ) =>
   (data: unknown): ParseSuccess<T[number]> | ParseFailure => {
@@ -38,7 +38,7 @@ export const union =
  * Represent an optional property, which is different from a required property that can be `undefined`.
  * @param parser
  */
-export const optional = <T>(parser: RequiredParser<T>): OptionalParser<T> =>
+export const optional = <T>(parser: Parser<T>): OptionalParser<T> =>
   /*
    * { [optionalValue]: true } is used at runtime by `object` to check if a validator represents an optional value.
    */
@@ -46,14 +46,12 @@ export const optional = <T>(parser: RequiredParser<T>): OptionalParser<T> =>
     [optionalSymbol]: true,
   }) as unknown as OptionalParser<T>
 
-export const nullable = <T>(
-  parser: RequiredParser<T>,
-): RequiredParser<T | null> => union(parseNull, parser)
+export const nullable = <T>(parser: Parser<T>): Parser<T | null> =>
+  union(parseNull, parser)
 
-export const undefineable = <T>(
-  parser: RequiredParser<T>,
-): RequiredParser<T | undefined> => union(parseUndefined, parser)
+export const undefineable = <T>(parser: Parser<T>): Parser<T | undefined> =>
+  union(parseUndefined, parser)
 
 export const optionalNullable = <T>(
-  parser: RequiredParser<T>,
+  parser: Parser<T>,
 ): OptionalParser<T | null> => optional(nullable(parser))


### PR DESCRIPTION
## What?

Removed 

- `RequiredParser`
- `RequiredParseResult`
- `OptionalParseResult`
- `FallibleParser`

Added:

- `isFailure`

## Why?

Since #43, they're redundant
