### PR TITLE
perf: compiled object validator

### DIFF
--- a/packages/pure-parse/.vitepress/config.ts
+++ b/packages/pure-parse/.vitepress/config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
           { text: 'Guards', link: '/guide/guards' },
           { text: 'Failsafe Parsing', link: '/guide/fallbacks' },
           { text: 'Performance', link: '/guide/performance' },
+          { text: 'Security', link: '/guide/security' },
           {
             text: 'Comparison',
             link: '/guide/comparison',

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -23,27 +23,32 @@ Loose assertion means that the function checks if the object conforms to the sch
 
 | Function                                              | Mops/s | Relative to PureParse |
 | ----------------------------------------------------- | ------ | --------------------- |
-| [PureParse](https://www.npmjs.com/package/pure-parse) | 75.5   | 100%                  |
+| [PureParse](/api/guard/objectGuard#objectGuard)\*     | 75.5   | 100%                  |
+| [PureParse](/api/guard/objectGuard#objectGuardNoEval) | 5.7    | 7.5%                  |
 | [Zod](https://www.npmjs.com/package/zod)              | 1.12   | 1.4%                  |
-| [Joi](https://www.npmjs.com/package/joi)\*            | —      | —                     |
 | [io-ts](https://www.npmjs.com/package/io-ts)          | 3.5    | 4.7%                  |
-| [Ajv](https://www.npmjs.com/package/ajv)              | 49     | 65%                   |
-| [Yup](https://www.npmjs.com/package/yup)              | 84     | 120%                  |
-| [Typia](https://www.npmjs.com/package/typia)          | 101    | 136%                  |
+| [Ajv](https://www.npmjs.com/package/ajv)\*            | 49     | 65%                   |
+| [Yup](https://www.npmjs.com/package/yup)\*            | 84     | 120%                  |
+| [Typia](https://www.npmjs.com/package/typia)\*\*      | 101    | 136%                  |
+
+\* Just-in-time (JIT) compilation<br>
+\*\* Ahead-of-time compilation<br>
 
 Safe parsing means that a copy of the parsed data is returned, which contains only those properties that were declared. This protects against prototype pollution, and corresponds to PureParse's parsers.
 
-| Function                                              | Mops/s | Relative to PureParse |
-| ----------------------------------------------------- | ------ | --------------------- |
-| [PureParse](https://www.npmjs.com/package/pure-parse) | 28.4   | 100%                  |
-| [Zod](https://www.npmjs.com/package/zod)              | 1.13   | 3.9%                  |
-| [Joi](https://www.npmjs.com/package/joi) \*           | —      | —                     |
-| [io-ts](https://www.npmjs.com/package/io-ts)\*        | —      | —                     |
-| [Ajv](https://www.npmjs.com/package/ajv)\*            | —      | —                     |
-| [Yup](https://www.npmjs.com/package/yup)              | 81.4   | 286%                  |
-| [Typia](https://www.npmjs.com/package/typia)          | 57.7   | 203%                  |
+| Function                                         | Mops/s | Relative to PureParse |
+| ------------------------------------------------ | ------ | --------------------- |
+| [PureParse](/api/parse/object#object)\*          | 28.4   | 100%                  |
+| [PureParse](/api/parse/object#objectNoEval)      | 4.1    | 5.5%                  |
+| [Zod](https://www.npmjs.com/package/zod)         | 1.13   | 3.9%                  |
+| [io-ts](https://www.npmjs.com/package/io-ts)†    | —      | —                     |
+| [Ajv](https://www.npmjs.com/package/ajv)\*†      | —      | —                     |
+| [Yup](https://www.npmjs.com/package/yup)\*       | 81.4   | 286%                  |
+| [Typia](https://www.npmjs.com/package/typia)\*\* | 57.7   | 203%                  |
 
-\*No benchmark data available
+\* Just-in-time (JIT) compilation<br>
+\*\* Ahead-of-time compilation<br>
+†No benchmark data available—the operation might not be supported<br>
 
 ## Size Comparison
 

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -6,11 +6,41 @@ For a more detailed comparison, see the [overview](./overview).
 
 ## Performance Benchmarks
 
-PureParse is benchmarked against other validation libraries:
+PureParse is benchmarked against other validation libraries; see https://moltar.github.io/typescript-runtime-type-benchmarks/.
 
-- It's roughtly 4× faster than Zod
-- If not memoized, it is slower than the compiled validation libraries (like Typia and Ajv)
-- If memoized, it is as fast as any JavaScript-based validation library can be.
+Here are some results as measured on October, 2024:
+
+- Chip: Apple M1 Pro
+- Memory: 16 GB
+
+> [!IMPORTANT]
+> The benchmark measures a very specific use case: the performance of parsing/validating a small object with only required properties, of which one is another object. Not all parsers in the table below have the same feature set.
+
+Loose assertion means that the function checks if the object conforms to the schema, and does not invalidate data that contains unknown properties. This corresponds to PureParse's guard functions:
+
+| Function                                              | Mops/s | Relative to PureParse |
+| ----------------------------------------------------- | ------ | --------------------- |
+| [PureParse](https://www.npmjs.com/package/pure-parse) | 74.4   | 100%                  |
+| [Zod](https://www.npmjs.com/package/zod)              | 1.12   | 1.4%                  |
+| [Joi](https://www.npmjs.com/package/joi)\*            | —      | —                     |
+| [io-ts](https://www.npmjs.com/package/io-ts)          | 3.5    | 4.7%                  |
+| [Ajv](https://www.npmjs.com/package/ajv)              | 49     | 65%                   |
+| [Yup](https://www.npmjs.com/package/yup)              | 84     | 120%                  |
+| [Typia](https://www.npmjs.com/package/typia)          | 101    | 136%                  |
+
+Safe parsing means that a copy of the parsed data is returned, which contains only those properties that were declared. This protects against prototype pollution, and corresponds to PureParse's parsers.
+
+| Function                                              | Mops/s | Relative to PureParse |
+| ----------------------------------------------------- | ------ | --------------------- |
+| [PureParse](https://www.npmjs.com/package/pure-parse) | 28.4   | 100%                  |
+| [Zod](https://www.npmjs.com/package/zod)              | 1.13   | 3.9%                  |
+| [Joi](https://www.npmjs.com/package/joi) \*           | —      | —                     |
+| [io-ts](https://www.npmjs.com/package/io-ts)\*        | —      | —                     |
+| [Ajv](https://www.npmjs.com/package/ajv)\*            | —      | —                     |
+| [Yup](https://www.npmjs.com/package/yup)              | 81.4   | 286%                  |
+| [Typia](https://www.npmjs.com/package/typia)          | 57.7   | 203%                  |
+
+\*No benchmark data available
 
 ## Size Comparison
 

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -23,7 +23,7 @@ Loose assertion means that the function checks if the object conforms to the sch
 
 | Function                                              | Mops/s | Relative to PureParse |
 | ----------------------------------------------------- | ------ | --------------------- |
-| [PureParse](https://www.npmjs.com/package/pure-parse) | 74.4   | 100%                  |
+| [PureParse](https://www.npmjs.com/package/pure-parse) | 75.5   | 100%                  |
 | [Zod](https://www.npmjs.com/package/zod)              | 1.12   | 1.4%                  |
 | [Joi](https://www.npmjs.com/package/joi)\*            | —      | —                     |
 | [io-ts](https://www.npmjs.com/package/io-ts)          | 3.5    | 4.7%                  |

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -14,7 +14,10 @@ Here are some results as measured on October, 2024:
 - Memory: 16 GB
 
 > [!IMPORTANT]
-> The benchmark measures a very specific use case: the performance of parsing/validating a small object with only required properties, of which one is another object. Not all parsers in the table below have the same feature set.
+> The benchmark measures a very specific use case: the performance of parsing/validating a small object with required properties, one of which is another object:
+
+> [!IMPORTANT]
+> Not all parsers in the tables below have the same feature set, so the benchmarks are not entirely comparable.
 
 Loose assertion means that the function checks if the object conforms to the schema, and does not invalidate data that contains unknown properties. This corresponds to PureParse's guard functions:
 
@@ -51,6 +54,9 @@ Safe parsing means that a copy of the parsed data is returned, which contains on
 | [Joi](https://www.npmjs.com/package/joi)              | 236 kB            |
 | [Ajv](https://www.npmjs.com/package/ajv)              | 32 kB             |
 | [Yup](https://www.npmjs.com/package/yup)              | 60 kB             |
+| [Typia](https://www.npmjs.com/package/typia)\*        | —                 |
+
+\*Typia is a compiler
 
 > [!NOTE]
 > Even though other libraries might be much larger, the final contribution to the bundle size will depend on whether the library is tree-shakeable, how tree-shakeable it is, and how many features of the library are used in the application.
@@ -65,22 +71,22 @@ Zod is more difficult to extend with custom validation logic. (In PureParse, you
 
 In Joi, you can annotate the schemas with a type alias, but it does not validate the schema completely. As such, there is no real type safety.
 
-Joi can't infer the type from a schema.
+Joi cannot infer the type from a schema.
 
 ## Ajv
 
-Ajv is a JSON Schema validator, which serves different purpose than PureParse.
-
-Ajv compiles JSON Schemas into JavaScript, which leads to fast execution. However, the JSON schema syntax is verbose, does not interoperate well with TypeScript, and does not lend itself well to customization of validation logic.
+Ajv is a JSON validator and conforms to the JSON Schema specification. However, the JSON schema syntax is verbose, does not interoperate well with TypeScript, and does not lend itself well to customization of validation logic.
 
 ## Yup
 
 Yup cannot _correctly_ infer the type from schemas—you can infer something, but it is not 100% correct.
 
-Yup does allow asynchronous validation, which PureParse does (yet) not support.
-
-Yup can be very slow.
+Yup does allow asynchronous validation.
 
 ## Typia
 
-Typia is a compiler that generates validation logic based on type aliases. The resulting code is incredibly fast, but customization happens in comments via a domain specific language, rather than with regular JavaScript code. When working with immutable data structures, PureParse can outperform Typia thanks to memoization.
+Typia is a compiler that generates validation logic based on type aliases. The resulting code is fast, and the boilerplate is minimal, but customization happens in a non-standard [comments](https://typia.io/docs/validators/tags/#comment-tags) and so-called [type-tags](https://typia.io/docs/validators/tags/#type-tags)—also non-standard. In PureParse, this happens in regular JavaScript code.
+
+When working with immutable data structures, PureParse can outperform Typia thanks to memoization.
+
+Typia does not have error messages.

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -19,7 +19,9 @@ Here are some results as measured on October, 2024:
 > [!IMPORTANT]
 > Not all parsers in the tables below have the same feature set, so the benchmarks are not entirely comparable.
 
-Loose assertion means that the function checks if the object conforms to the schema, and does not invalidate data that contains unknown properties. This corresponds to PureParse's guard functions:
+### Loose Assertion
+
+_Loose assertion_ means that the function checks if the object conforms to the schema, and does not invalidate data that contains unknown properties. This corresponds to PureParse's guard functions:
 
 | Function                                              | Mops/s | Relative to PureParse |
 | ----------------------------------------------------- | ------ | --------------------- |
@@ -34,7 +36,9 @@ Loose assertion means that the function checks if the object conforms to the sch
 \* Just-in-time (JIT) compilation<br>
 \*\* Ahead-of-time compilation<br>
 
-Safe parsing means that a copy of the parsed data is returned, which contains only those properties that were declared. This protects against prototype pollution, and corresponds to PureParse's parsers.
+### Safe Parsing
+
+_Safe parsing_ means that a copy of the parsed data is returned, which contains only those properties that were declared. This protects against prototype pollution, and corresponds to PureParse's parsers.
 
 | Function                                         | Mops/s | Relative to PureParse |
 | ------------------------------------------------ | ------ | --------------------- |
@@ -48,7 +52,7 @@ Safe parsing means that a copy of the parsed data is returned, which contains on
 
 \* Just-in-time (JIT) compilation<br>
 \*\* Ahead-of-time compilation<br>
-†No benchmark data available—the operation might not be supported<br>
+†No benchmark data available—the operation might not be supported by the library<br>
 
 ## Size Comparison
 

--- a/packages/pure-parse/docs/guide/comparison.md
+++ b/packages/pure-parse/docs/guide/comparison.md
@@ -23,15 +23,15 @@ Here are some results as measured on October, 2024:
 
 _Loose assertion_ means that the function checks if the object conforms to the schema, and does not invalidate data that contains unknown properties. This corresponds to PureParse's guard functions:
 
-| Function                                              | Mops/s | Relative to PureParse |
-| ----------------------------------------------------- | ------ | --------------------- |
-| [PureParse](/api/guard/objectGuard#objectGuard)\*     | 75.5   | 100%                  |
-| [PureParse](/api/guard/objectGuard#objectGuardNoEval) | 5.7    | 7.5%                  |
-| [Zod](https://www.npmjs.com/package/zod)              | 1.12   | 1.4%                  |
-| [io-ts](https://www.npmjs.com/package/io-ts)          | 3.5    | 4.7%                  |
-| [Ajv](https://www.npmjs.com/package/ajv)\*            | 49     | 65%                   |
-| [Yup](https://www.npmjs.com/package/yup)\*            | 84     | 120%                  |
-| [Typia](https://www.npmjs.com/package/typia)\*\*      | 101    | 136%                  |
+| Function                                             | Mops/s | Relative to PureParse |
+| ---------------------------------------------------- | ------ | --------------------- |
+| [PureParse](/api/guard/validation#objectGuard)\*     | 75.5   | 100%                  |
+| [PureParse](/api/guard/validation#objectGuardNoEval) | 5.7    | 7.5%                  |
+| [Zod](https://www.npmjs.com/package/zod)             | 1.12   | 1.4%                  |
+| [io-ts](https://www.npmjs.com/package/io-ts)         | 3.5    | 4.7%                  |
+| [Ajv](https://www.npmjs.com/package/ajv)\*           | 49     | 65%                   |
+| [Yup](https://www.npmjs.com/package/yup)\*           | 84     | 120%                  |
+| [Typia](https://www.npmjs.com/package/typia)\*\*     | 101    | 136%                  |
 
 \* Just-in-time (JIT) compilation<br>
 \*\* Ahead-of-time compilation<br>

--- a/packages/pure-parse/docs/guide/overview.md
+++ b/packages/pure-parse/docs/guide/overview.md
@@ -61,9 +61,11 @@ By having a small size, and by being tree-shakable, [PureParse](https://www.npmj
 
 ## Fast
 
-When the document changes raidly over time—such as in a real-time collaborative editor—validation may need to be performed several times per second. As long as the document in question is using immutable data structures, the validation logic can be memoized, which gives a huge performance boost.
+PureParse is [one of the fastest](comparison.md#performance-benchmarks) validators.
 
-[Read more](comparison.md#performance-benchmarks)
+When working with immutable data structures, memoization can help increase performance by orders of magnitude. It is especially useful when the parsed data is being rendered to the screen with a functional UI library like React. For React to be able to skip re-rendering, the references in the parsed result must be stable, which is achieved with memoization.
+
+[Read more](performance)
 
 ## Fail-safe
 

--- a/packages/pure-parse/docs/guide/performance.md
+++ b/packages/pure-parse/docs/guide/performance.md
@@ -3,7 +3,11 @@
 PureParse is built to be fast. But when dealing with immutable data structures, parsing can be near instantaneous.
 
 > [!TIP]
-> For benchmarks, see the [Comparison > Benchmarks](comparison#benchmarks) section.
+> For performance benchmarks, see the [Comparison > Benchmarks](comparison#benchmarks) section.
+
+## Just-in-Time (JIT) Compilation
+
+PureParse owes its great performance to just-in-time compilation: when constructing a parser, the argument gets compiled at runtime into a function that can be optimized by V8 (and other JavaScript engines). This technique is used by all the fastest validation libraries.
 
 ## Memoization
 

--- a/packages/pure-parse/docs/guide/security.md
+++ b/packages/pure-parse/docs/guide/security.md
@@ -1,0 +1,21 @@
+# Security
+
+PureParse is designed to be secure by default.
+
+## Prototype Pollution
+
+To protect your app against prototype pollution, it is recommended to use the parsers instead of the guard functions. The parsers return a copy of the parsed data, which contains only those properties that were declared.
+
+## Content Security Policy
+
+To use PureParse in a
+browser page that enables
+[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) (CSP), either:
+
+1. Use `objectNoJit` and `objectGuardNoJit` instead of `object` and `objectGuard`.
+2. Enable the `unsafe-eval` directive in the CSP header.
+
+PureParse itself is safe from XSS, but websites sometimes indiscriminately forbid the usage of `eval` and the `Function` constructor in their entire source code. PureParse's `object` and `objectGuard` functions use the `Function` constructor for increased performance will thus be affected if the CSP header is enabled. The `objectNoJit` and `objectGuardNoJit` functions are alternative implementations that are somewhat slower, but are immune to CSP restrictions.
+
+> [!TIP]
+> For more information on the performance differences, see the [benchmarks](/guide/comparison.html#performance-benchmarks).

--- a/packages/pure-parse/docs/index.md
+++ b/packages/pure-parse/docs/index.md
@@ -29,7 +29,7 @@ features:
   - title: Fast
     icon:
       src: /guage.svg
-    details: 4 times the speed of Zod. Memoize for even faster validation.
+    details: Among the fastest validators. Memoize for even better performance.
     link: /guide/overview#fast
   - title: Fail-safe
     icon:

--- a/packages/pure-parse/src/common/Infer.test.ts
+++ b/packages/pure-parse/src/common/Infer.test.ts
@@ -1,5 +1,10 @@
 import { describe, it } from 'vitest'
-import { isBoolean, isNumber, isString, object as objectGuard } from '../guard'
+import {
+  isBoolean,
+  isNumber,
+  isString,
+  objectGuard as objectGuard,
+} from '../guard'
 import { Infer } from './Infer'
 import { Equals } from '../internals'
 import { parseBoolean, parseNumber, parseString, object } from '../parse'

--- a/packages/pure-parse/src/common/memo.test.ts
+++ b/packages/pure-parse/src/common/memo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { memo } from './memo'
 import { parseNumber, parseString, object } from '../parse'
-import { isNumber, isString, object as objectGuard } from '../guard'
+import { isNumber, isString, objectGuard as objectGuard } from '../guard'
 
 describe('arrays', () => {
   it('works with parsers', () => {

--- a/packages/pure-parse/src/guard/README.test.ts
+++ b/packages/pure-parse/src/guard/README.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { array, literal, object, union, Guard } from './validation'
+import { array, literal, objectGuard, union, Guard } from './validation'
 import { isString } from './guards'
 
 describe('README examples', () => {
@@ -12,7 +12,7 @@ describe('README examples', () => {
     const leaf =
       <T>(guard: Guard<T>) =>
       (data: unknown): data is Leaf<T> =>
-        object({
+        objectGuard({
           tag: literal('leaf'),
           data: guard,
         })(data)
@@ -22,7 +22,7 @@ describe('README examples', () => {
       (data: unknown): data is Tree<T> =>
         union(
           leaf(guard),
-          object({
+          objectGuard({
             tag: literal('tree'),
             data: array(union(leaf(guard), tree(guard))),
           }),

--- a/packages/pure-parse/src/guard/README.test.ts
+++ b/packages/pure-parse/src/guard/README.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { array, literal, objectGuard, union, Guard } from './validation'
+import { arrayGuard, literal, objectGuard, union, Guard } from './validation'
 import { isString } from './guards'
 
 describe('README examples', () => {
@@ -24,7 +24,7 @@ describe('README examples', () => {
           leaf(guard),
           objectGuard({
             tag: literal('tree'),
-            data: array(union(leaf(guard), tree(guard))),
+            data: arrayGuard(union(leaf(guard), tree(guard))),
           }),
         )(data)
     describe('leaf', () => {

--- a/packages/pure-parse/src/guard/json.test.ts
+++ b/packages/pure-parse/src/guard/json.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import { isJsonValue } from './json'
-import { object, isNumber, isString, isUnknown } from './index'
 
 describe('json', () => {
   describe('validation', () => {

--- a/packages/pure-parse/src/guard/json.ts
+++ b/packages/pure-parse/src/guard/json.ts
@@ -1,4 +1,4 @@
-import { array, partialRecord, union } from './validation'
+import { arrayGuard, partialRecord, union } from './validation'
 import { isBoolean, isNull, isNumber, isString } from './guards'
 import { JsonValue } from '../common'
 
@@ -9,5 +9,5 @@ export const isJsonValue = (data: unknown): data is JsonValue =>
     isNumber,
     isString,
     partialRecord(isString, isJsonValue),
-    array(isJsonValue),
+    arrayGuard(isJsonValue),
   )(data)

--- a/packages/pure-parse/src/guard/validation.test.ts
+++ b/packages/pure-parse/src/guard/validation.test.ts
@@ -3,6 +3,7 @@ import {
   array,
   partialRecord,
   objectGuard,
+  objectGuardNoEval,
   union,
   literal,
   optional,
@@ -24,918 +25,910 @@ import {
 } from './guards'
 import { Infer } from '../common'
 
-describe('validation', () => {
-  describe('algebraic data types', () => {
-    describe('literal types', () => {
+describe('literal types', () => {
+  describe('type checking', () => {
+    describe('type inference', () => {
+      it('works with literals', () => {
+        const symb = Symbol()
+        literal(symb) satisfies Guard<typeof symb>
+        literal('red') satisfies Guard<'red'>
+        // @ts-expect-error
+        literal('red') satisfies Guard<'green'>
+        literal(1) satisfies Guard<1>
+        // @ts-expect-error
+        literal(1) satisfies Guard<2>
+      })
+      it('forbids non-literals', () => {
+        // @ts-expect-error
+        literal([])
+        // @ts-expect-error
+        literal({})
+      })
+    })
+    describe('explicit generic type annotation', () => {
+      it('works with literals', () => {
+        literal<['red']>('red')
+        // @ts-expect-error
+        literal<['green']>('red')
+
+        literal<[1]>(1)
+        // @ts-expect-error
+        literal<[1]>(2)
+
+        // @ts-expect-error
+        literal<['1']>(1)
+      })
+    })
+  })
+  describe('unions of literals', () => {
+    it('validates unions of literals correctly', () => {
+      const isColor = literal('red', 'green', 'blue')
+      expect(isColor('red')).toEqual(true)
+      expect(isColor('green')).toEqual(true)
+      expect(isColor('blue')).toEqual(true)
+      expect(isColor('music')).toEqual(false)
+
+      const isInUnion = literal('red', 1, true)
+      expect(isInUnion('red')).toEqual(true)
+      expect(isInUnion('green')).toEqual(false)
+      expect(isInUnion(1)).toEqual(true)
+      expect(isInUnion(2)).toEqual(false)
+      expect(isInUnion(true)).toEqual(true)
+      expect(isInUnion(false)).toEqual(false)
+    })
+    it('infers the types of unions of literals', () => {
+      literal('red', 1, true) satisfies Guard<'red' | 1 | true>
+      literal('red', 'green', 'blue') satisfies Guard<'red' | 'green' | 'blue'>
+      // @ts-expect-error
+      literal('red', 'green', 'blue') satisfies Guard<'red'>
+    })
+    test('explicit type annotation', () => {
+      literal<['red', 'green', 'blue']>('red', 'green', 'blue')
+      // @ts-expect-error
+      literal<['red', 'green', 'blue']>('red')
+      // @ts-expect-error
+      literal<['red', 'green', 'blue']>('red', 'green', 'blue', 'music')
+    })
+  })
+  describe('primitive', () => {
+    it('matches null', () => {
+      expect(literal(null)(null)).toEqual(true)
+    })
+    it('matches undefined', () => {
+      expect(literal(undefined)(undefined)).toEqual(true)
+    })
+    it('matches strings', () => {
+      expect(literal('')('')).toEqual(true)
+      expect(literal('a')('a')).toEqual(true)
+      expect(literal('abc')('123')).toEqual(false)
+    })
+    it('matches numbers', () => {
+      expect(literal(-1)(-1)).toEqual(true)
+      expect(literal(0)(0)).toEqual(true)
+      expect(literal(1)(1)).toEqual(true)
+
+      expect(literal(123)('123')).toEqual(false)
+    })
+    it('matches booleans', () => {
+      expect(literal(true)(true)).toEqual(true)
+      expect(literal(false)(false)).toEqual(true)
+      expect(literal(true)(false)).toEqual(false)
+      expect(literal(false)(true)).toEqual(false)
+    })
+  })
+})
+describe('sum types', () => {
+  describe('unions', () => {
+    describe('type checking', () => {
+      it('returns a guard', () => {
+        union(
+          literal('red'),
+          literal('green'),
+          literal('blue'),
+        ) satisfies Guard<'red' | 'green' | 'blue'>
+        union(isString, isUndefined) satisfies Guard<string | undefined>
+        union(isString, isNumber) satisfies Guard<string | number>
+        union(isString) satisfies Guard<string>
+
+        union(
+          literal('red'),
+          literal('green'),
+          literal('blue'),
+          // @ts-expect-error
+        ) satisfies Guard<'a' | 'b' | 'c'>
+        union(
+          literal('red'),
+          literal('green'),
+          literal('blue'),
+          // @ts-expect-error
+        ) satisfies Guard<'red'>
+        // @ts-expect-error
+        union(isString, isUndefined) satisfies Guard<string>
+      })
+      describe('explicit generic type annotation', () => {
+        it('works with literals', () => {
+          union<['red', 'green', 'blue']>(
+            literal('red'),
+            literal('green'),
+            literal('blue'),
+          )
+          union<['red', 'green', 'blue']>(
+            // @ts-expect-error
+            literal('a'),
+            literal('b'),
+            literal('c'),
+          )
+        })
+        it('requires a guard of each type', () => {
+          union<[string, undefined]>(isString, isUndefined)
+          // @ts-expect-error
+          union<[string, undefined]>(isUndefined)
+          // @ts-expect-error
+          union<[string, undefined]>(isString)
+        })
+        it('allows nested guards', () => {
+          union<[string, number, undefined | null]>(
+            isString,
+            isNumber,
+            union(isUndefined, isNull),
+          )
+        })
+        it('handles primitive types', () => {
+          union<[string, undefined]>(isString, isUndefined)
+          union<[string, number]>(isString, isNumber)
+          // @ts-expect-error
+          union<[string, undefined]>(union(isString))
+          // @ts-expect-error
+          union<string>(union(isString, isUndefined))
+        })
+      })
+    })
+    it('does not match anything when the array is empty', () => {
+      const isUnion = union()
+      expect(isUnion('a')).toEqual(false)
+      expect(isUnion(true)).toEqual(false)
+      expect(isUnion(false)).toEqual(false)
+      expect(isUnion(null)).toEqual(false)
+      expect(isUnion(undefined)).toEqual(false)
+    })
+    it('matches any of the the guards in the array', () => {
+      const isUnion = union(isString, isNumber, isNull)
+      expect(isUnion('a')).toEqual(true)
+      expect(isUnion(123)).toEqual(true)
+      expect(isUnion(null)).toEqual(true)
+    })
+    it('only matches the guards in the array', () => {
+      const isUnion = union(isString, isNumber, isNull)
+      expect(isUnion('a')).toEqual(true)
+      expect(isUnion(123)).toEqual(true)
+      expect(isUnion(null)).toEqual(true)
+
+      expect(isUnion(true)).toEqual(false)
+      expect(isUnion(false)).toEqual(false)
+      expect(isUnion(undefined)).toEqual(false)
+    })
+  })
+  describe('generic property guards', () => {
+    it('allows for generic, higher-order validation function', () => {
+      type TreeNode<T> = {
+        data: T
+      }
+
+      const isTreeNode = <T>(
+        isData: (data: unknown) => data is T,
+      ): Guard<TreeNode<T>> =>
+        objectGuard({
+          // In v0.0.0-beta.3, this caused a problem with optional properties.
+          // Because data can be undefined, it got interpreted as an optional property, which clashed with the
+          // definition of `TreeNode` which declares it as required.
+          data: isData,
+        })
+    })
+  })
+  describe('optional', () => {
+    it('matches undefined', () => {
+      expect(optional(isString)(undefined)).toEqual(true)
+    })
+    it('mismatches undefined', () => {
+      expect(optional(isString)(null)).toEqual(false)
+    })
+    it('matches the guard type of the guard argument', () => {
+      expect(optional(isBoolean)(true)).toEqual(true)
+      expect(optional(isNumber)(123)).toEqual(true)
+      expect(optional(isString)('hello')).toEqual(true)
+    })
+    it('only matches the guard type of the guard argument', () => {
+      expect(optional(isBoolean)(123)).toEqual(false)
+      expect(optional(isNumber)('hello')).toEqual(false)
+      expect(optional(isString)(true)).toEqual(false)
+    })
+    it('represent optional properties', () => {
+      const isObj = objectGuard({
+        a: optional(isString),
+      })
+      expect(isObj({ a: 'hello' })).toEqual(true)
+      expect(isObj({ a: undefined })).toEqual(true)
+      expect(isObj({})).toEqual(true)
+    })
+    test('type inference', () => {
+      const isObj = objectGuard({
+        id: isNumber,
+        name: optional(isString),
+      })
+      type User = {
+        id: number
+        name?: string
+      }
+      type InferredUser = Infer<typeof isObj>
+      // @ts-expect-error -- TODO can't get this to work
+      const t1: Equals<User, InferredUser> = true
+      const t2: InferredUser = {
+        id: 0,
+        name: 'Johannes',
+      }
+      // @ts-expect-error -- TODO can't get this to work
+      const t3: InferredUser = {
+        id: 0,
+      }
+      const t4: InferredUser = {
+        id: 0,
+        name: undefined,
+      }
+    })
+  })
+  describe('nullable', () => {
+    it('matches undefined', () => {
+      expect(nullable(isString)(undefined)).toEqual(false)
+    })
+    it('mismatches undefined', () => {
+      expect(nullable(isString)(null)).toEqual(true)
+    })
+    it('matches the guard type of the guard argument', () => {
+      expect(nullable(isBoolean)(true)).toEqual(true)
+      expect(nullable(isNumber)(123)).toEqual(true)
+      expect(nullable(isString)('hello')).toEqual(true)
+    })
+    it('only matches the guard type of the guard argument', () => {
+      expect(nullable(isBoolean)(123)).toEqual(false)
+      expect(nullable(isNumber)('hello')).toEqual(false)
+      expect(nullable(isString)(true)).toEqual(false)
+    })
+  })
+  describe('optionalNullable', () => {
+    it('matches undefined', () => {
+      expect(optionalNullable(isString)(undefined)).toEqual(true)
+    })
+    it('mismatches undefined', () => {
+      expect(optionalNullable(isString)(null)).toEqual(true)
+    })
+    it('matches the guard type of the guard argument', () => {
+      expect(optionalNullable(isBoolean)(true)).toEqual(true)
+      expect(optionalNullable(isNumber)(123)).toEqual(true)
+      expect(optionalNullable(isString)('hello')).toEqual(true)
+    })
+    it('only matches the guard type of the guard argument', () => {
+      expect(optionalNullable(isBoolean)(123)).toEqual(false)
+      expect(optionalNullable(isNumber)('hello')).toEqual(false)
+      expect(optionalNullable(isString)(true)).toEqual(false)
+    })
+    it('represent optional properties', () => {
+      const isObj = objectGuard({
+        a: optionalNullable(isString),
+      })
+      expect(isObj({ a: 'hello' })).toEqual(true)
+      expect(isObj({ a: undefined })).toEqual(true)
+      expect(isObj({ a: null })).toEqual(true)
+      expect(isObj({})).toEqual(true)
+    })
+  })
+  describe('nullable', () => {
+    it('mismatches undefined', () => {
+      expect(nullable(isString)(undefined)).toEqual(false)
+    })
+    it('matches null', () => {
+      expect(nullable(isString)(null)).toEqual(true)
+    })
+    it('matches the guard type of the guard argument', () => {
+      expect(nullable(isBoolean)(true)).toEqual(true)
+      expect(nullable(isNumber)(123)).toEqual(true)
+      expect(nullable(isString)('hello')).toEqual(true)
+    })
+    it('only matches the guard type of the guard argument', () => {
+      expect(nullable(isBoolean)(123)).toEqual(false)
+      expect(nullable(isNumber)('hello')).toEqual(false)
+      expect(nullable(isString)(true)).toEqual(false)
+    })
+  })
+  describe('undefinable', () => {
+    it('matches undefined', () => {
+      expect(undefineable(isString)(undefined)).toEqual(true)
+    })
+    it('mismatches null', () => {
+      expect(undefineable(isString)(null)).toEqual(false)
+    })
+    it('matches the guard type of the guard argument', () => {
+      expect(undefineable(isBoolean)(true)).toEqual(true)
+      expect(undefineable(isNumber)(123)).toEqual(true)
+      expect(undefineable(isString)('hello')).toEqual(true)
+    })
+    it('only matches the guard type of the guard argument', () => {
+      expect(undefineable(isBoolean)(123)).toEqual(false)
+      expect(undefineable(isNumber)('hello')).toEqual(false)
+      expect(undefineable(isString)(true)).toEqual(false)
+    })
+  })
+})
+describe('tuples', () => {
+  describe('type checking', () => {
+    it('returns a guard', () => {
+      tuple([]) satisfies Guard<[]>
+      tuple([isString]) satisfies Guard<[string]>
+      tuple([isString, isNumber]) satisfies Guard<[string, number]>
+      tuple([isNumber, isNumber, isNumber]) satisfies Guard<
+        [number, number, number]
+      >
+
+      // @ts-expect-error
+      tuple([isNumber]) satisfies Guard<[number, number]>
+      // @ts-expect-error
+      tuple([isString, isString]) satisfies Guard<[number, number]>
+      // @ts-expect-error
+      tuple([isNumber, isNumber]) satisfies Guard<[string, string]>
+    })
+    test('explicit generic type annotation', () => {
+      tuple<[]>([])
+      tuple<[string]>([isString])
+      tuple<[string, number]>([isString, isNumber])
+      tuple<[number, number, number]>([isNumber, isNumber, isNumber])
+      // @ts-expect-error
+      tuple<[number, number]>([isNumber])
+      // @ts-expect-error
+      tuple<[number, number]>([isString, isString])
+      // @ts-expect-error
+      tuple<[string, string]>([isNumber, isNumber])
+    })
+  })
+  it('validates each element', () => {
+    expect(tuple([])([])).toEqual(true)
+    expect(tuple([isString])(['hello'])).toEqual(true)
+    expect(tuple([isString, isNumber])(['hello', 123])).toEqual(true)
+    expect(
+      tuple([isString, isNumber, isBoolean])(['hello', 123, false]),
+    ).toEqual(true)
+  })
+  it('does not allow additional elements', () => {
+    expect(tuple([])([1])).toEqual(false)
+    expect(tuple([isString])(['hello', 'hello again'])).toEqual(false)
+    expect(tuple([isString, isNumber])(['hello', 123, true])).toEqual(false)
+  })
+  it('does not allow fewer elements', () => {
+    expect(tuple([isBoolean])([])).toEqual(false)
+    expect(tuple([isString, isString])(['hello'])).toEqual(false)
+    expect(tuple([isString, isNumber])([])).toEqual(false)
+  })
+})
+
+const suits = [
+  {
+    name: 'objectNoEval',
+    fn: objectGuardNoEval,
+  },
+  {
+    name: 'objectEval',
+    fn: objectGuard,
+  },
+  //   TODO objectGuardMemo
+]
+
+suits.forEach(({ name: suiteName, fn: objectGuard }) => {
+  describe(suiteName, () => {
+    describe('objects', () => {
       describe('type checking', () => {
-        describe('type inference', () => {
-          it('works with literals', () => {
-            const symb = Symbol()
-            literal(symb) satisfies Guard<typeof symb>
-            literal('red') satisfies Guard<'red'>
+        it('returns a guard', () => {
+          objectGuard({ a: isString }) satisfies Guard<{ a: string }>
+          objectGuard({ a: isNumber }) satisfies Guard<{ a: number }>
+          objectGuard({
+            a: objectGuard({
+              b: isNumber,
+            }),
+          }) satisfies Guard<{ a: { b: number } }>
+
+          // @ts-expect-error
+          objectGuard({ a: isString }) satisfies Guard<{ a: number }>
+          // @ts-expect-error
+          objectGuard({ a: isNumber }) satisfies Guard<{ a: string }>
+          // @ts-expect-error
+          objectGuard({ a: isNumber }) satisfies Guard<{ x: number }>
+
+          objectGuard({
+            a: objectGuard({ b: isNumber }),
             // @ts-expect-error
-            literal('red') satisfies Guard<'green'>
-            literal(1) satisfies Guard<1>
+          }) satisfies Guard<{ a: { b: string } }>
+
+          objectGuard({
+            b: objectGuard({
+              b: isNumber,
+            }),
             // @ts-expect-error
-            literal(1) satisfies Guard<2>
-          })
-          it('forbids non-literals', () => {
-            // @ts-expect-error
-            literal([])
-            // @ts-expect-error
-            literal({})
-          })
+          }) satisfies Guard<{ x: { y: number } }>
         })
         describe('explicit generic type annotation', () => {
-          it('works with literals', () => {
-            literal<['red']>('red')
-            // @ts-expect-error
-            literal<['green']>('red')
-
-            literal<[1]>(1)
-            // @ts-expect-error
-            literal<[1]>(2)
-
-            // @ts-expect-error
-            literal<['1']>(1)
-          })
-        })
-      })
-      describe('unions of literals', () => {
-        it('validates unions of literals correctly', () => {
-          const isColor = literal('red', 'green', 'blue')
-          expect(isColor('red')).toEqual(true)
-          expect(isColor('green')).toEqual(true)
-          expect(isColor('blue')).toEqual(true)
-          expect(isColor('music')).toEqual(false)
-
-          const isInUnion = literal('red', 1, true)
-          expect(isInUnion('red')).toEqual(true)
-          expect(isInUnion('green')).toEqual(false)
-          expect(isInUnion(1)).toEqual(true)
-          expect(isInUnion(2)).toEqual(false)
-          expect(isInUnion(true)).toEqual(true)
-          expect(isInUnion(false)).toEqual(false)
-        })
-        it('infers the types of unions of literals', () => {
-          literal('red', 1, true) satisfies Guard<'red' | 1 | true>
-          literal('red', 'green', 'blue') satisfies Guard<
-            'red' | 'green' | 'blue'
-          >
-          // @ts-expect-error
-          literal('red', 'green', 'blue') satisfies Guard<'red'>
-        })
-        test('explicit type annotation', () => {
-          literal<['red', 'green', 'blue']>('red', 'green', 'blue')
-          // @ts-expect-error
-          literal<['red', 'green', 'blue']>('red')
-          // @ts-expect-error
-          literal<['red', 'green', 'blue']>('red', 'green', 'blue', 'music')
-        })
-      })
-      describe('primitive', () => {
-        it('matches null', () => {
-          expect(literal(null)(null)).toEqual(true)
-        })
-        it('matches undefined', () => {
-          expect(literal(undefined)(undefined)).toEqual(true)
-        })
-        it('matches strings', () => {
-          expect(literal('')('')).toEqual(true)
-          expect(literal('a')('a')).toEqual(true)
-          expect(literal('abc')('123')).toEqual(false)
-        })
-        it('matches numbers', () => {
-          expect(literal(-1)(-1)).toEqual(true)
-          expect(literal(0)(0)).toEqual(true)
-          expect(literal(1)(1)).toEqual(true)
-
-          expect(literal(123)('123')).toEqual(false)
-        })
-        it('matches booleans', () => {
-          expect(literal(true)(true)).toEqual(true)
-          expect(literal(false)(false)).toEqual(true)
-          expect(literal(true)(false)).toEqual(false)
-          expect(literal(false)(true)).toEqual(false)
-        })
-      })
-    })
-    describe('sum types', () => {
-      describe('unions', () => {
-        describe('type checking', () => {
-          it('returns a guard', () => {
-            union(
-              literal('red'),
-              literal('green'),
-              literal('blue'),
-            ) satisfies Guard<'red' | 'green' | 'blue'>
-            union(isString, isUndefined) satisfies Guard<string | undefined>
-            union(isString, isNumber) satisfies Guard<string | number>
-            union(isString) satisfies Guard<string>
-
-            union(
-              literal('red'),
-              literal('green'),
-              literal('blue'),
-              // @ts-expect-error
-            ) satisfies Guard<'a' | 'b' | 'c'>
-            union(
-              literal('red'),
-              literal('green'),
-              literal('blue'),
-              // @ts-expect-error
-            ) satisfies Guard<'red'>
-            // @ts-expect-error
-            union(isString, isUndefined) satisfies Guard<string>
-          })
-          describe('explicit generic type annotation', () => {
-            it('works with literals', () => {
-              union<['red', 'green', 'blue']>(
-                literal('red'),
-                literal('green'),
-                literal('blue'),
-              )
-              union<['red', 'green', 'blue']>(
-                // @ts-expect-error
-                literal('a'),
-                literal('b'),
-                literal('c'),
-              )
+          it('handles optional properties', () => {
+            type User1 = {
+              id: number
+              name: string
+            }
+            objectGuard<User1>({
+              id: isNumber,
+              name: isString,
             })
-            it('requires a guard of each type', () => {
-              union<[string, undefined]>(isString, isUndefined)
+            objectGuard<User1>({
+              id: isNumber,
               // @ts-expect-error
-              union<[string, undefined]>(isUndefined)
-              // @ts-expect-error
-              union<[string, undefined]>(isString)
+              name: optional(isString),
             })
-            it('allows nested guards', () => {
-              union<[string, number, undefined | null]>(
-                isString,
-                isNumber,
-                union(isUndefined, isNull),
-              )
+
+            type UserUndefinable = {
+              id: number
+              name: string | undefined
+            }
+            objectGuard<UserUndefinable>({
+              id: isNumber,
+              // required property, union of string and undefined
+              name: undefineable(isString),
             })
-            it('handles primitive types', () => {
-              union<[string, undefined]>(isString, isUndefined)
-              union<[string, number]>(isString, isNumber)
-              // @ts-expect-error
-              union<[string, undefined]>(union(isString))
-              // @ts-expect-error
-              union<string>(union(isString, isUndefined))
+            objectGuard<UserUndefinable>({
+              id: isNumber,
+              // @ts-expect-error - name can be undefined, but it is not optional
+              name: optional(isString),
             })
-          })
-        })
-        it('does not match anything when the array is empty', () => {
-          const isUnion = union()
-          expect(isUnion('a')).toEqual(false)
-          expect(isUnion(true)).toEqual(false)
-          expect(isUnion(false)).toEqual(false)
-          expect(isUnion(null)).toEqual(false)
-          expect(isUnion(undefined)).toEqual(false)
-        })
-        it('matches any of the the guards in the array', () => {
-          const isUnion = union(isString, isNumber, isNull)
-          expect(isUnion('a')).toEqual(true)
-          expect(isUnion(123)).toEqual(true)
-          expect(isUnion(null)).toEqual(true)
-        })
-        it('only matches the guards in the array', () => {
-          const isUnion = union(isString, isNumber, isNull)
-          expect(isUnion('a')).toEqual(true)
-          expect(isUnion(123)).toEqual(true)
-          expect(isUnion(null)).toEqual(true)
-
-          expect(isUnion(true)).toEqual(false)
-          expect(isUnion(false)).toEqual(false)
-          expect(isUnion(undefined)).toEqual(false)
-        })
-      })
-      describe('generic property guards', () => {
-        it('allows for generic, higher-order validation function', () => {
-          type TreeNode<T> = {
-            data: T
-          }
-
-          const isTreeNode = <T>(
-            isData: (data: unknown) => data is T,
-          ): Guard<TreeNode<T>> =>
-            objectGuard({
-              // In v0.0.0-beta.3, this caused a problem with optional properties.
-              // Because data can be undefined, it got interpreted as an optional property, which clashed with the
-              // definition of `TreeNode` which declares it as required.
-              data: isData,
+            objectGuard<UserUndefinable>({
+              id: isNumber,
+              // string is more narrow than string | undefined, which means that if the validation passes for string, it satisfies User2
+              name: isString,
             })
-        })
-      })
-      describe('optional', () => {
-        it('matches undefined', () => {
-          expect(optional(isString)(undefined)).toEqual(true)
-        })
-        it('mismatches undefined', () => {
-          expect(optional(isString)(null)).toEqual(false)
-        })
-        it('matches the guard type of the guard argument', () => {
-          expect(optional(isBoolean)(true)).toEqual(true)
-          expect(optional(isNumber)(123)).toEqual(true)
-          expect(optional(isString)('hello')).toEqual(true)
-        })
-        it('only matches the guard type of the guard argument', () => {
-          expect(optional(isBoolean)(123)).toEqual(false)
-          expect(optional(isNumber)('hello')).toEqual(false)
-          expect(optional(isString)(true)).toEqual(false)
-        })
-        it('represent optional properties', () => {
-          const isObj = objectGuard({
-            a: optional(isString),
-          })
-          expect(isObj({ a: 'hello' })).toEqual(true)
-          expect(isObj({ a: undefined })).toEqual(true)
-          expect(isObj({})).toEqual(true)
-        })
-        test('type inference', () => {
-          const isObj = objectGuard({
-            id: isNumber,
-            name: optional(isString),
-          })
-          type User = {
-            id: number
-            name?: string
-          }
-          type InferredUser = Infer<typeof isObj>
-          // @ts-expect-error -- TODO can't get this to work
-          const t1: Equals<User, InferredUser> = true
-          const t2: InferredUser = {
-            id: 0,
-            name: 'Johannes',
-          }
-          // @ts-expect-error -- TODO can't get this to work
-          const t3: InferredUser = {
-            id: 0,
-          }
-          const t4: InferredUser = {
-            id: 0,
-            name: undefined,
-          }
-        })
-      })
-      describe('nullable', () => {
-        it('matches undefined', () => {
-          expect(nullable(isString)(undefined)).toEqual(false)
-        })
-        it('mismatches undefined', () => {
-          expect(nullable(isString)(null)).toEqual(true)
-        })
-        it('matches the guard type of the guard argument', () => {
-          expect(nullable(isBoolean)(true)).toEqual(true)
-          expect(nullable(isNumber)(123)).toEqual(true)
-          expect(nullable(isString)('hello')).toEqual(true)
-        })
-        it('only matches the guard type of the guard argument', () => {
-          expect(nullable(isBoolean)(123)).toEqual(false)
-          expect(nullable(isNumber)('hello')).toEqual(false)
-          expect(nullable(isString)(true)).toEqual(false)
-        })
-      })
-      describe('optionalNullable', () => {
-        it('matches undefined', () => {
-          expect(optionalNullable(isString)(undefined)).toEqual(true)
-        })
-        it('mismatches undefined', () => {
-          expect(optionalNullable(isString)(null)).toEqual(true)
-        })
-        it('matches the guard type of the guard argument', () => {
-          expect(optionalNullable(isBoolean)(true)).toEqual(true)
-          expect(optionalNullable(isNumber)(123)).toEqual(true)
-          expect(optionalNullable(isString)('hello')).toEqual(true)
-        })
-        it('only matches the guard type of the guard argument', () => {
-          expect(optionalNullable(isBoolean)(123)).toEqual(false)
-          expect(optionalNullable(isNumber)('hello')).toEqual(false)
-          expect(optionalNullable(isString)(true)).toEqual(false)
-        })
-        it('represent optional properties', () => {
-          const isObj = objectGuard({
-            a: optionalNullable(isString),
-          })
-          expect(isObj({ a: 'hello' })).toEqual(true)
-          expect(isObj({ a: undefined })).toEqual(true)
-          expect(isObj({ a: null })).toEqual(true)
-          expect(isObj({})).toEqual(true)
-        })
-      })
-      describe('nullable', () => {
-        it('mismatches undefined', () => {
-          expect(nullable(isString)(undefined)).toEqual(false)
-        })
-        it('matches null', () => {
-          expect(nullable(isString)(null)).toEqual(true)
-        })
-        it('matches the guard type of the guard argument', () => {
-          expect(nullable(isBoolean)(true)).toEqual(true)
-          expect(nullable(isNumber)(123)).toEqual(true)
-          expect(nullable(isString)('hello')).toEqual(true)
-        })
-        it('only matches the guard type of the guard argument', () => {
-          expect(nullable(isBoolean)(123)).toEqual(false)
-          expect(nullable(isNumber)('hello')).toEqual(false)
-          expect(nullable(isString)(true)).toEqual(false)
-        })
-      })
-      describe('undefinable', () => {
-        it('matches undefined', () => {
-          expect(undefineable(isString)(undefined)).toEqual(true)
-        })
-        it('mismatches null', () => {
-          expect(undefineable(isString)(null)).toEqual(false)
-        })
-        it('matches the guard type of the guard argument', () => {
-          expect(undefineable(isBoolean)(true)).toEqual(true)
-          expect(undefineable(isNumber)(123)).toEqual(true)
-          expect(undefineable(isString)('hello')).toEqual(true)
-        })
-        it('only matches the guard type of the guard argument', () => {
-          expect(undefineable(isBoolean)(123)).toEqual(false)
-          expect(undefineable(isNumber)('hello')).toEqual(false)
-          expect(undefineable(isString)(true)).toEqual(false)
-        })
-      })
-    })
-    describe('product types', () => {
-      describe('tuples', () => {
-        describe('type checking', () => {
-          it('returns a guard', () => {
-            tuple([]) satisfies Guard<[]>
-            tuple([isString]) satisfies Guard<[string]>
-            tuple([isString, isNumber]) satisfies Guard<[string, number]>
-            tuple([isNumber, isNumber, isNumber]) satisfies Guard<
-              [number, number, number]
-            >
+            objectGuard<UserUndefinable>({
+              id: isNumber,
+              // undefined is more narrow than string | undefined, which means that if the validation passes for undefined, it satisfies User2
+              name: isUndefined,
+            })
+            // @ts-expect-error
+            objectGuard<UserUndefinable>({
+              id: isNumber,
+              // If we don't check the property, we have no type information on the field (it's unknown).
+              //  Therefore, the fact that it's optional should not mean that we can skip validation
+              // name: isString,
+            })
 
-            // @ts-expect-error
-            tuple([isNumber]) satisfies Guard<[number, number]>
-            // @ts-expect-error
-            tuple([isString, isString]) satisfies Guard<[number, number]>
-            // @ts-expect-error
-            tuple([isNumber, isNumber]) satisfies Guard<[string, string]>
-          })
-          test('explicit generic type annotation', () => {
-            tuple<[]>([])
-            tuple<[string]>([isString])
-            tuple<[string, number]>([isString, isNumber])
-            tuple<[number, number, number]>([isNumber, isNumber, isNumber])
-            // @ts-expect-error
-            tuple<[number, number]>([isNumber])
-            // @ts-expect-error
-            tuple<[number, number]>([isString, isString])
-            // @ts-expect-error
-            tuple<[string, string]>([isNumber, isNumber])
-          })
-        })
-        it('validates each element', () => {
-          expect(tuple([])([])).toEqual(true)
-          expect(tuple([isString])(['hello'])).toEqual(true)
-          expect(tuple([isString, isNumber])(['hello', 123])).toEqual(true)
-          expect(
-            tuple([isString, isNumber, isBoolean])(['hello', 123, false]),
-          ).toEqual(true)
-        })
-        it('does not allow additional elements', () => {
-          expect(tuple([])([1])).toEqual(false)
-          expect(tuple([isString])(['hello', 'hello again'])).toEqual(false)
-          expect(tuple([isString, isNumber])(['hello', 123, true])).toEqual(
-            false,
-          )
-        })
-        it('does not allow fewer elements', () => {
-          expect(tuple([isBoolean])([])).toEqual(false)
-          expect(tuple([isString, isString])(['hello'])).toEqual(false)
-          expect(tuple([isString, isNumber])([])).toEqual(false)
-        })
-      })
-      describe('objects', () => {
-        describe('type checking', () => {
-          it('returns a guard', () => {
-            objectGuard({ a: isString }) satisfies Guard<{ a: string }>
-            objectGuard({ a: isNumber }) satisfies Guard<{ a: number }>
-            objectGuard({
-              a: objectGuard({
-                b: isNumber,
-              }),
-            }) satisfies Guard<{ a: { b: number } }>
-
-            // @ts-expect-error
-            objectGuard({ a: isString }) satisfies Guard<{ a: number }>
-            // @ts-expect-error
-            objectGuard({ a: isNumber }) satisfies Guard<{ a: string }>
-            // @ts-expect-error
-            objectGuard({ a: isNumber }) satisfies Guard<{ x: number }>
-
-            objectGuard({
-              a: objectGuard({ b: isNumber }),
-              // @ts-expect-error
-            }) satisfies Guard<{ a: { b: string } }>
-
-            objectGuard({
-              b: objectGuard({
-                b: isNumber,
-              }),
-              // @ts-expect-error
-            }) satisfies Guard<{ x: { y: number } }>
-          })
-          describe('explicit generic type annotation', () => {
-            it('handles optional properties', () => {
-              type User1 = {
-                id: number
-                name: string
-              }
-              objectGuard<User1>({
-                id: isNumber,
-                name: isString,
-              })
-              objectGuard<User1>({
-                id: isNumber,
-                // @ts-expect-error
-                name: optional(isString),
-              })
-
-              type UserUndefinable = {
-                id: number
-                name: string | undefined
-              }
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // required property, union of string and undefined
-                name: undefineable(isString),
-              })
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // @ts-expect-error - name can be undefined, but it is not optional
-                name: optional(isString),
-              })
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // string is more narrow than string | undefined, which means that if the validation passes for string, it satisfies User2
-                name: isString,
-              })
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // undefined is more narrow than string | undefined, which means that if the validation passes for undefined, it satisfies User2
-                name: isUndefined,
-              })
-              // @ts-expect-error
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // If we don't check the property, we have no type information on the field (it's unknown).
-                //  Therefore, the fact that it's optional should not mean that we can skip validation
-                // name: isString,
-              })
-
-              type UserOptional = {
-                id: number
-                // This one is optional, not a union with undefined
-                name?: string
-              }
-              const doNotEvenTry = () => {
-                // May or may not throw an exception. The point is that it should give a type error.
-                objectGuard<UserOptional>({
-                  id: isNumber,
-                  // Similarly to above; the property must have a corresponding validation function
-                  // @ts-expect-error
-                  name: undefined,
-                })
-              }
+            type UserOptional = {
+              id: number
+              // This one is optional, not a union with undefined
+              name?: string
+            }
+            const doNotEvenTry = () => {
+              // May or may not throw an exception. The point is that it should give a type error.
               objectGuard<UserOptional>({
                 id: isNumber,
-                // @ts-expect-error - requires optional function
-                name: union(isUndefined, isString),
-              })
-              objectGuard<UserOptional>({
-                id: isNumber,
-                // As expected; requires the optional function
-                name: optional(isString),
-              })
-            })
-            it('works with complex objects', () => {
-              type User1 = {
-                id: number
-                name: string
-                address?: {
-                  country: string
-                  city: string
-                  streetAddress: string
-                  zipCode: number
-                }
-              }
-              objectGuard<User1>({
-                id: isNumber,
-                name: isString,
-                address: optional(
-                  objectGuard({
-                    country: isString,
-                    city: isString,
-                    streetAddress: isString,
-                    zipCode: isNumber,
-                  }),
-                ),
-              })
-              type User2 = {
-                // Changed the type of id to string to check erros
-                id: string
-                name: string
-                address?: {
-                  country: string
-                  city: string
-                  streetAddress: string
-                  zipCode: number
-                }
-              }
-
-              objectGuard<User2>({
+                // Similarly to above; the property must have a corresponding validation function
                 // @ts-expect-error
-                id: isNumber,
-                name: isString,
-                address: optional(
-                  objectGuard({
-                    country: isString,
-                    city: isString,
-                    streetAddress: isString,
-                    zipCode: isNumber,
-                  }),
-                ),
+                name: undefined,
               })
+            }
+            objectGuard<UserOptional>({
+              id: isNumber,
+              // @ts-expect-error - requires optional function
+              name: union(isUndefined, isString),
+            })
+            objectGuard<UserOptional>({
+              id: isNumber,
+              // As expected; requires the optional function
+              name: optional(isString),
             })
           })
-          test('explicit generic type annotation', () => {
-            objectGuard<{ a: string }>({ a: isString })
-            objectGuard<{ a: number }>({ a: isNumber })
-            objectGuard<{ a: { b: string } }>({
-              a: objectGuard({ b: isString }),
+          it('works with complex objects', () => {
+            type User1 = {
+              id: number
+              name: string
+              address?: {
+                country: string
+                city: string
+                streetAddress: string
+                zipCode: number
+              }
+            }
+            objectGuard<User1>({
+              id: isNumber,
+              name: isString,
+              address: optional(
+                objectGuard({
+                  country: isString,
+                  city: isString,
+                  streetAddress: isString,
+                  zipCode: isNumber,
+                }),
+              ),
             })
+            type User2 = {
+              // Changed the type of id to string to check erros
+              id: string
+              name: string
+              address?: {
+                country: string
+                city: string
+                streetAddress: string
+                zipCode: number
+              }
+            }
 
+            objectGuard<User2>({
+              // @ts-expect-error
+              id: isNumber,
+              name: isString,
+              address: optional(
+                objectGuard({
+                  country: isString,
+                  city: isString,
+                  streetAddress: isString,
+                  zipCode: isNumber,
+                }),
+              ),
+            })
+          })
+        })
+        test('explicit generic type annotation', () => {
+          objectGuard<{ a: string }>({ a: isString })
+          objectGuard<{ a: number }>({ a: isNumber })
+          objectGuard<{ a: { b: string } }>({
+            a: objectGuard({ b: isString }),
+          })
+
+          // @ts-expect-error
+          objectGuard<{ a: number }>({ a: isString })
+          // @ts-expect-error
+          objectGuard<{ a: string }>({ a: isNumber })
+          objectGuard<{ a: { b: string } }>({
             // @ts-expect-error
-            objectGuard<{ a: number }>({ a: isString })
+            a: objectGuard({ b: isNumber }),
+          })
+          objectGuard<{ a: { b: string } }>({
             // @ts-expect-error
-            objectGuard<{ a: string }>({ a: isNumber })
-            objectGuard<{ a: { b: string } }>({
-              // @ts-expect-error
-              a: objectGuard({ b: isNumber }),
-            })
-            objectGuard<{ a: { b: string } }>({
-              // @ts-expect-error
-              x: objectGuard({ y: isNumber }),
-            })
-          })
-        })
-        it('validates null', () => {
-          const isObj = objectGuard({})
-          expect(isObj(null)).toEqual(false)
-        })
-        it('validates undefined', () => {
-          const isObj = objectGuard({})
-          expect(isObj(undefined)).toEqual(false)
-        })
-        it('validates empty records', () => {
-          const isObj = objectGuard({})
-          expect(isObj({})).toEqual(true)
-        })
-        it('allows unknown properties', () => {
-          const isObj = objectGuard({})
-          expect(isObj({ a: 'unexpected!' })).toEqual(true)
-        })
-        it('validates required properties', () => {
-          const isObj = objectGuard({
-            a: isString,
-          })
-          expect(
-            isObj({
-              a: 'hello',
-            }),
-          ).toEqual(true)
-          expect(isObj({})).toEqual(false)
-          expect(isObj({ a: undefined })).toEqual(false)
-        })
-        test('that undefinable properties are required', () => {
-          const isObj = objectGuard({
-            a: undefineable(isString),
-          })
-          expect(
-            isObj({
-              a: 'hello',
-            }),
-          ).toEqual(true)
-          expect(isObj({})).toEqual(false)
-          expect(isObj({ a: undefined })).toEqual(true)
-        })
-        it('validates optional properties', () => {
-          const isObj = objectGuard({
-            a: optional(isString),
-          })
-          expect(
-            isObj({
-              a: 'hello',
-            }),
-          ).toEqual(true)
-          expect(isObj({})).toEqual(true)
-          expect(isObj({ a: undefined })).toEqual(true)
-        })
-        it('differentiates between undefined and missing properties', () => {
-          const isOptionalObj = objectGuard({
-            a: optional(isString),
-          })
-          expect(isOptionalObj({})).toEqual(true)
-          expect(isOptionalObj({ a: undefined })).toEqual(true)
-          const isUnionObj = objectGuard({
-            a: union(isString, isUndefined),
-          })
-          expect(isUnionObj({})).toEqual(false)
-          expect(isUnionObj({ a: undefined })).toEqual(true)
-        })
-      })
-      describe('partial records', () => {
-        describe('type checking', () => {
-          it('returns a guard', () => {
-            partialRecord(isString, isString) satisfies Guard<
-              Partial<Record<string, string>>
-            >
-            partialRecord(isString, isNumber) satisfies Guard<
-              Partial<Record<string, number>>
-            >
-            // @ts-expect-error
-            partialRecord(isString, isString) satisfies Guard<
-              Partial<Record<string, number>>
-            >
-          })
-          describe('explicit generic type annotation', () => {
-            test('string as key', () => {
-              partialRecord<string, string>(isString, isString)
-              partialRecord<string, number[]>(isString, array(isNumber))
-              // @ts-expect-error
-              partialRecord<string, string>(isString, isNumber)
-              // @ts-expect-error
-              partialRecord<string, number[]>(isString, array(isString))
-            })
-            test('literal union as key', () => {
-              partialRecord<'a', string>(literal('a'), isString)
-              // @ts-expect-error
-              partialRecord<'a', string>(isString, isString)
-              // @ts-expect-error
-              partialRecord<'a', string>(literal('b'), isString)
-            })
-          })
-        })
-        it('validates null', () => {
-          expect(partialRecord(isString, isString)(null)).toEqual(false)
-        })
-        it('validates undefined', () => {
-          expect(partialRecord(isString, isString)(undefined)).toEqual(false)
-        })
-        it('validates empty records', () => {
-          expect(partialRecord(isString, isString)({})).toEqual(true)
-        })
-        it('invalidates empty arrays', () => {
-          expect(partialRecord(isString, isString)([])).toEqual(false)
-        })
-        it('invalidates arrays', () => {
-          expect(partialRecord(isString, isString)(['a'])).toEqual(false)
-        })
-        it('validates records where the type of the keys match', () => {
-          expect(
-            partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
-          ).toEqual(true)
-          expect(partialRecord(isString, isNumber)({ a: 1, b: 1 })).toEqual(
-            true,
-          )
-          expect(
-            partialRecord(isString, isBoolean)({ a: true, b: false }),
-          ).toEqual(true)
-        })
-        it('invalidates records where the type of any key does not match', () => {
-          expect(
-            partialRecord(isString, isString)({ a: 'hello', b: 1 }),
-          ).toEqual(false)
-          expect(
-            partialRecord(isString, isNumber)({ a: 'hello', b: 1 }),
-          ).toEqual(false)
-          expect(
-            partialRecord(isString, isBoolean)({ a: 'hello', b: true }),
-          ).toEqual(false)
-        })
-        test('extra properties in the schema', () => {
-          const isObj = objectGuard({
-            a: isNumber,
-            // @ts-expect-error - all properties must be guard functions
-            b: 123,
-          })
-        })
-        describe('keys', () => {
-          it('allows keys to be of type string', () => {
-            expect(
-              partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(partialRecord(isString, isString)({})).toEqual(true)
-          })
-          it('does not allow extra keys', () => {
-            const isKey = union(literal('a'), literal('b'))
-            expect(
-              partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(
-              partialRecord(
-                isKey,
-                isString,
-              )({ a: 'hello', b: 'hello2', c: 'hello3' }),
-            ).toEqual(false)
-          })
-          it('allows each key to be omitted', () => {
-            const isKey = union(literal('a'), literal('b'))
-            expect(
-              partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(partialRecord(isKey, isString)({ a: 'hello' })).toEqual(true)
-            expect(partialRecord(isKey, isString)({})).toEqual(true)
+            x: objectGuard({ y: isNumber }),
           })
         })
       })
-      describe('records', () => {
-        describe('type checking', () => {
-          it('returns a guard', () => {
-            const keys = ['a', 'b', 'c'] as const
-            record(keys, isString) satisfies Guard<Record<string, string>>
-            record(keys, isNumber) satisfies Guard<Record<string, number>>
-            // @ts-expect-error
-            record(keys, isString) satisfies Guard<Record<string, number>>
-          })
-          describe('explicit generic type annotation', () => {
-            test('string as key', () => {})
-            test('literal union as key', () => {
-              record<['a', 'b'], string>(['a', 'b'], isString)
-              record<['a', 'b'], number[]>(['a', 'b'], array(isNumber))
-              // @ts-expect-error
-              record<['a', 'b'], string>(['a', 'b'], isNumber)
-              // @ts-expect-error
-              record<['a', 'b'], number[]>(['a', 'b'], array(isString))
-            })
-          })
+      it('validates null', () => {
+        const isObj = objectGuard({})
+        expect(isObj(null)).toEqual(false)
+      })
+      it('validates undefined', () => {
+        const isObj = objectGuard({})
+        expect(isObj(undefined)).toEqual(false)
+      })
+      it('validates empty records', () => {
+        const isObj = objectGuard({})
+        expect(isObj({})).toEqual(true)
+      })
+      it('allows unknown properties', () => {
+        const isObj = objectGuard({})
+        expect(isObj({ a: 'unexpected!' })).toEqual(true)
+      })
+      it('validates required properties', () => {
+        const isObj = objectGuard({
+          a: isString,
         })
-        it('validates null', () => {
-          expect(record([], isString)(null)).toEqual(false)
+        expect(
+          isObj({
+            a: 'hello',
+          }),
+        ).toEqual(true)
+        expect(isObj({})).toEqual(false)
+        expect(isObj({ a: undefined })).toEqual(false)
+      })
+      test('that undefinable properties are required', () => {
+        const isObj = objectGuard({
+          a: undefineable(isString),
         })
-        it('validates undefined', () => {
-          expect(record([], isString)(undefined)).toEqual(false)
+        expect(
+          isObj({
+            a: 'hello',
+          }),
+        ).toEqual(true)
+        expect(isObj({})).toEqual(false)
+        expect(isObj({ a: undefined })).toEqual(true)
+      })
+      it('validates optional properties', () => {
+        const isObj = objectGuard({
+          a: optional(isString),
         })
-        it('validates empty records', () => {
-          expect(record([], isString)({})).toEqual(true)
+        expect(
+          isObj({
+            a: 'hello',
+          }),
+        ).toEqual(true)
+        expect(isObj({})).toEqual(true)
+        expect(isObj({ a: undefined })).toEqual(true)
+      })
+      it('differentiates between undefined and missing properties', () => {
+        const isOptionalObj = objectGuard({
+          a: optional(isString),
         })
-        it('invalidates empty arrays', () => {
-          expect(record([], isString)([])).toEqual(false)
+        expect(isOptionalObj({})).toEqual(true)
+        expect(isOptionalObj({ a: undefined })).toEqual(true)
+        const isUnionObj = objectGuard({
+          a: union(isString, isUndefined),
         })
-        it('invalidates arrays', () => {
-          expect(record([], isString)(['a'])).toEqual(false)
-        })
-        it('validates records where the type of the keys match', () => {
-          expect(
-            record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
-          ).toEqual(true)
-          expect(record(['a', 'b'], isNumber)({ a: 1, b: 1 })).toEqual(true)
-          expect(record(['a', 'b'], isBoolean)({ a: true, b: false })).toEqual(
-            true,
-          )
-        })
-        it('invalidates records where the type of any key does not match', () => {
-          expect(record(['a', 'b'], isString)({ a: 'hello', b: 1 })).toEqual(
-            false,
-          )
-          expect(record(['a', 'b'], isNumber)({ a: 'hello', b: 1 })).toEqual(
-            false,
-          )
-          expect(
-            record(['a', 'b'], isBoolean)({ a: 'hello', b: true }),
-          ).toEqual(false)
-        })
-        describe('keys', () => {
-          it('allows keys to be of type string', () => {
-            expect(
-              record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-          })
-          it('requires all keys to be present', () => {
-            expect(
-              record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(record(['a', 'b'], isString)({ a: 'hello' })).toEqual(false)
-            expect(record(['a', 'b'], isString)({ b: 'hello2' })).toEqual(false)
-          })
-          it('does not allow extra keys', () => {
-            expect(
-              record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(
-              record(
-                ['a', 'b'],
-                isString,
-              )({ a: 'hello', b: 'hello2', c: 'hello3' }),
-            ).toEqual(false)
-          })
-          it('handles optional keys', () => {
-            expect(
-              record(
-                ['a', 'b'],
-                optional(isString),
-              )({ a: 'hello', b: 'hello2' }),
-            ).toEqual(true)
-            expect(
-              record(['a', 'b'], optional(isString))({ a: 'hello' }),
-            ).toEqual(true)
-            expect(record(['a', 'b'], optional(isString))({})).toEqual(true)
-          })
-        })
+        expect(isUnionObj({})).toEqual(false)
+        expect(isUnionObj({ a: undefined })).toEqual(true)
       })
     })
-    describe('recursive types', () => {
-      describe('isArray', () => {
-        describe('types', () => {
-          it('returns a guard', () => {
-            array(isString) satisfies Guard<string[]>
-            // @ts-expect-error
-            array(isString) satisfies Guard<number[]>
-          })
-          it('infers the exact type', () => {
-            // Number
-            const isNumberArray = array((d): d is number => true)
-            type NumberArray = Infer<typeof isNumberArray>
-            const assertionNumber1: Equals<NumberArray, number[]> = true
-            const assertionNumber2: Equals<NumberArray, unknown[]> = false
-            // String
-            const isStringArray = array(isString)
-            type StringArray = Infer<typeof isStringArray>
-            const assertionString1: Equals<StringArray, string[]> = true
-            const assertionString2: Equals<StringArray, unknown[]> = false
-          })
-          test('explicit generic type annotation', () => {
-            array<number>(isNumber)
-            array<string>(isString)
-            array<string | number>(union(isString, isNumber))
-            // @ts-expect-error
-            array<number>(union(isString, isNumber))
-            // @ts-expect-error
-            array<string>(isNumber)
-            // @ts-expect-error
-            array<string[]>(isString)
-            // @ts-expect-error
-            array<string>(array(isNumber))
-          })
-        })
-        it('validates null', () => {
-          expect(array(isUnknown)(null)).toEqual(false)
-        })
-        it('validates undefined', () => {
-          expect(array(isUnknown)(undefined)).toEqual(false)
-        })
-        it('validates unassigned values', () => {
-          let data
-          expect(array(isUnknown)(data)).toEqual(false)
-        })
-        it('validates booleans', () => {
-          expect(array(isUnknown)(false)).toEqual(false)
-          expect(array(isUnknown)(true)).toEqual(false)
-        })
-        it('validates numbers', () => {
-          expect(array(isUnknown)(NaN)).toEqual(false)
-          expect(array(isUnknown)(Infinity)).toEqual(false)
-          expect(array(isUnknown)(0)).toEqual(false)
-          expect(array(isUnknown)(1)).toEqual(false)
-          expect(array(isUnknown)(3.14159)).toEqual(false)
-        })
-        it('validates strings', () => {
-          expect(array(isUnknown)('')).toEqual(false)
-          expect(array(isUnknown)('hello')).toEqual(false)
-        })
-        it('validates symbols', () => {
-          expect(array(isUnknown)(Symbol())).toEqual(false)
-        })
-        it('validates objects', () => {
-          expect(array(isUnknown)({})).toEqual(false)
-        })
-        it('validates empty arrays', () => {
-          expect(array(isUnknown)([])).toEqual(true)
-        })
-        it('always validates empty arrays', () => {
-          expect(array(isUnknown)([])).toEqual(true)
-          expect(array(isString)([])).toEqual(true)
-          expect(array(isBoolean)([])).toEqual(true)
-          expect(array((data: unknown): data is unknown => false)([])).toEqual(
-            true,
-          )
-        })
-        it('expects every element to pass the validation', () => {
-          expect(array(union(isNumber))([1, 2, 3, 4])).toEqual(true)
-          expect(array(union(isNumber))([1, 2, 3, 'a', 4])).toEqual(false)
-          expect(
-            array(union(isString, isNumber, isBoolean))([1, 'a', false]),
-          ).toEqual(true)
-        })
+  })
+})
+
+describe('partial records', () => {
+  describe('type checking', () => {
+    it('returns a guard', () => {
+      partialRecord(isString, isString) satisfies Guard<
+        Partial<Record<string, string>>
+      >
+      partialRecord(isString, isNumber) satisfies Guard<
+        Partial<Record<string, number>>
+      >
+      // @ts-expect-error
+      partialRecord(isString, isString) satisfies Guard<
+        Partial<Record<string, number>>
+      >
+    })
+    describe('explicit generic type annotation', () => {
+      test('string as key', () => {
+        partialRecord<string, string>(isString, isString)
+        partialRecord<string, number[]>(isString, array(isNumber))
+        // @ts-expect-error
+        partialRecord<string, string>(isString, isNumber)
+        // @ts-expect-error
+        partialRecord<string, number[]>(isString, array(isString))
       })
+      test('literal union as key', () => {
+        partialRecord<'a', string>(literal('a'), isString)
+        // @ts-expect-error
+        partialRecord<'a', string>(isString, isString)
+        // @ts-expect-error
+        partialRecord<'a', string>(literal('b'), isString)
+      })
+    })
+  })
+  it('validates null', () => {
+    expect(partialRecord(isString, isString)(null)).toEqual(false)
+  })
+  it('validates undefined', () => {
+    expect(partialRecord(isString, isString)(undefined)).toEqual(false)
+  })
+  it('validates empty records', () => {
+    expect(partialRecord(isString, isString)({})).toEqual(true)
+  })
+  it('invalidates empty arrays', () => {
+    expect(partialRecord(isString, isString)([])).toEqual(false)
+  })
+  it('invalidates arrays', () => {
+    expect(partialRecord(isString, isString)(['a'])).toEqual(false)
+  })
+  it('validates records where the type of the keys match', () => {
+    expect(
+      partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
+    ).toEqual(true)
+    expect(partialRecord(isString, isNumber)({ a: 1, b: 1 })).toEqual(true)
+    expect(partialRecord(isString, isBoolean)({ a: true, b: false })).toEqual(
+      true,
+    )
+  })
+  it('invalidates records where the type of any key does not match', () => {
+    expect(partialRecord(isString, isString)({ a: 'hello', b: 1 })).toEqual(
+      false,
+    )
+    expect(partialRecord(isString, isNumber)({ a: 'hello', b: 1 })).toEqual(
+      false,
+    )
+    expect(partialRecord(isString, isBoolean)({ a: 'hello', b: true })).toEqual(
+      false,
+    )
+  })
+  test('extra properties in the schema', () => {
+    const isObj = objectGuard({
+      a: isNumber,
+      // @ts-expect-error - all properties must be guard functions
+      b: 123,
+    })
+  })
+  describe('keys', () => {
+    it('allows keys to be of type string', () => {
+      expect(
+        partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(partialRecord(isString, isString)({})).toEqual(true)
+    })
+    it('does not allow extra keys', () => {
+      const isKey = union(literal('a'), literal('b'))
+      expect(
+        partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(
+        partialRecord(
+          isKey,
+          isString,
+        )({ a: 'hello', b: 'hello2', c: 'hello3' }),
+      ).toEqual(false)
+    })
+    it('allows each key to be omitted', () => {
+      const isKey = union(literal('a'), literal('b'))
+      expect(
+        partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(partialRecord(isKey, isString)({ a: 'hello' })).toEqual(true)
+      expect(partialRecord(isKey, isString)({})).toEqual(true)
+    })
+  })
+})
+describe('records', () => {
+  describe('type checking', () => {
+    it('returns a guard', () => {
+      const keys = ['a', 'b', 'c'] as const
+      record(keys, isString) satisfies Guard<Record<string, string>>
+      record(keys, isNumber) satisfies Guard<Record<string, number>>
+      // @ts-expect-error
+      record(keys, isString) satisfies Guard<Record<string, number>>
+    })
+    describe('explicit generic type annotation', () => {
+      test('string as key', () => {})
+      test('literal union as key', () => {
+        record<['a', 'b'], string>(['a', 'b'], isString)
+        record<['a', 'b'], number[]>(['a', 'b'], array(isNumber))
+        // @ts-expect-error
+        record<['a', 'b'], string>(['a', 'b'], isNumber)
+        // @ts-expect-error
+        record<['a', 'b'], number[]>(['a', 'b'], array(isString))
+      })
+    })
+  })
+  it('validates null', () => {
+    expect(record([], isString)(null)).toEqual(false)
+  })
+  it('validates undefined', () => {
+    expect(record([], isString)(undefined)).toEqual(false)
+  })
+  it('validates empty records', () => {
+    expect(record([], isString)({})).toEqual(true)
+  })
+  it('invalidates empty arrays', () => {
+    expect(record([], isString)([])).toEqual(false)
+  })
+  it('invalidates arrays', () => {
+    expect(record([], isString)(['a'])).toEqual(false)
+  })
+  it('validates records where the type of the keys match', () => {
+    expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
+      true,
+    )
+    expect(record(['a', 'b'], isNumber)({ a: 1, b: 1 })).toEqual(true)
+    expect(record(['a', 'b'], isBoolean)({ a: true, b: false })).toEqual(true)
+  })
+  it('invalidates records where the type of any key does not match', () => {
+    expect(record(['a', 'b'], isString)({ a: 'hello', b: 1 })).toEqual(false)
+    expect(record(['a', 'b'], isNumber)({ a: 'hello', b: 1 })).toEqual(false)
+    expect(record(['a', 'b'], isBoolean)({ a: 'hello', b: true })).toEqual(
+      false,
+    )
+  })
+  describe('keys', () => {
+    it('allows keys to be of type string', () => {
+      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
+        true,
+      )
+    })
+    it('requires all keys to be present', () => {
+      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
+        true,
+      )
+      expect(record(['a', 'b'], isString)({ a: 'hello' })).toEqual(false)
+      expect(record(['a', 'b'], isString)({ b: 'hello2' })).toEqual(false)
+    })
+    it('does not allow extra keys', () => {
+      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
+        true,
+      )
+      expect(
+        record(['a', 'b'], isString)({ a: 'hello', b: 'hello2', c: 'hello3' }),
+      ).toEqual(false)
+    })
+    it('handles optional keys', () => {
+      expect(
+        record(['a', 'b'], optional(isString))({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(record(['a', 'b'], optional(isString))({ a: 'hello' })).toEqual(
+        true,
+      )
+      expect(record(['a', 'b'], optional(isString))({})).toEqual(true)
+    })
+  })
+})
+describe('recursive types', () => {
+  describe('isArray', () => {
+    describe('types', () => {
+      it('returns a guard', () => {
+        array(isString) satisfies Guard<string[]>
+        // @ts-expect-error
+        array(isString) satisfies Guard<number[]>
+      })
+      it('infers the exact type', () => {
+        // Number
+        const isNumberArray = array((d): d is number => true)
+        type NumberArray = Infer<typeof isNumberArray>
+        const assertionNumber1: Equals<NumberArray, number[]> = true
+        const assertionNumber2: Equals<NumberArray, unknown[]> = false
+        // String
+        const isStringArray = array(isString)
+        type StringArray = Infer<typeof isStringArray>
+        const assertionString1: Equals<StringArray, string[]> = true
+        const assertionString2: Equals<StringArray, unknown[]> = false
+      })
+      test('explicit generic type annotation', () => {
+        array<number>(isNumber)
+        array<string>(isString)
+        array<string | number>(union(isString, isNumber))
+        // @ts-expect-error
+        array<number>(union(isString, isNumber))
+        // @ts-expect-error
+        array<string>(isNumber)
+        // @ts-expect-error
+        array<string[]>(isString)
+        // @ts-expect-error
+        array<string>(array(isNumber))
+      })
+    })
+    it('validates null', () => {
+      expect(array(isUnknown)(null)).toEqual(false)
+    })
+    it('validates undefined', () => {
+      expect(array(isUnknown)(undefined)).toEqual(false)
+    })
+    it('validates unassigned values', () => {
+      let data
+      expect(array(isUnknown)(data)).toEqual(false)
+    })
+    it('validates booleans', () => {
+      expect(array(isUnknown)(false)).toEqual(false)
+      expect(array(isUnknown)(true)).toEqual(false)
+    })
+    it('validates numbers', () => {
+      expect(array(isUnknown)(NaN)).toEqual(false)
+      expect(array(isUnknown)(Infinity)).toEqual(false)
+      expect(array(isUnknown)(0)).toEqual(false)
+      expect(array(isUnknown)(1)).toEqual(false)
+      expect(array(isUnknown)(3.14159)).toEqual(false)
+    })
+    it('validates strings', () => {
+      expect(array(isUnknown)('')).toEqual(false)
+      expect(array(isUnknown)('hello')).toEqual(false)
+    })
+    it('validates symbols', () => {
+      expect(array(isUnknown)(Symbol())).toEqual(false)
+    })
+    it('validates objects', () => {
+      expect(array(isUnknown)({})).toEqual(false)
+    })
+    it('validates empty arrays', () => {
+      expect(array(isUnknown)([])).toEqual(true)
+    })
+    it('always validates empty arrays', () => {
+      expect(array(isUnknown)([])).toEqual(true)
+      expect(array(isString)([])).toEqual(true)
+      expect(array(isBoolean)([])).toEqual(true)
+      expect(array((data: unknown): data is unknown => false)([])).toEqual(true)
+    })
+    it('expects every element to pass the validation', () => {
+      expect(array(union(isNumber))([1, 2, 3, 4])).toEqual(true)
+      expect(array(union(isNumber))([1, 2, 3, 'a', 4])).toEqual(false)
+      expect(
+        array(union(isString, isNumber, isBoolean))([1, 'a', false]),
+      ).toEqual(true)
     })
   })
 })

--- a/packages/pure-parse/src/guard/validation.test.ts
+++ b/packages/pure-parse/src/guard/validation.test.ts
@@ -3,7 +3,7 @@ import {
   array,
   partialRecord,
   objectGuard,
-  objectGuardNoEval,
+  objectGuardNoJit,
   union,
   literal,
   optional,
@@ -411,7 +411,7 @@ describe('tuples', () => {
 const suits = [
   {
     name: 'objectNoEval',
-    fn: objectGuardNoEval,
+    fn: objectGuardNoJit,
   },
   {
     name: 'objectEval',

--- a/packages/pure-parse/src/guard/validation.test.ts
+++ b/packages/pure-parse/src/guard/validation.test.ts
@@ -490,24 +490,21 @@ describe('validation', () => {
                 //  Therefore, the fact that it's optional should not mean that we can skip validation
                 // name: isString,
               })
-              objectGuard<UserUndefinable>({
-                id: isNumber,
-                // Similarly to above; the property must have a corresponding validation function
-                // @ts-expect-error
-                name: undefined,
-              })
 
               type UserOptional = {
                 id: number
                 // This one is optional, not a union with undefined
                 name?: string
               }
-              objectGuard<UserOptional>({
-                id: isNumber,
-                // Similarly to above; the property must have a corresponding validation function
-                // @ts-expect-error
-                name: undefined,
-              })
+              const doNotEvenTry = () => {
+                // May or may not throw an exception. The point is that it should give a type error.
+                objectGuard<UserOptional>({
+                  id: isNumber,
+                  // Similarly to above; the property must have a corresponding validation function
+                  // @ts-expect-error
+                  name: undefined,
+                })
+              }
               objectGuard<UserOptional>({
                 id: isNumber,
                 // @ts-expect-error - requires optional function

--- a/packages/pure-parse/src/guard/validation.test.ts
+++ b/packages/pure-parse/src/guard/validation.test.ts
@@ -580,12 +580,12 @@ describe('validation', () => {
             objectGuard<{ a: number }>({ a: isString })
             // @ts-expect-error
             objectGuard<{ a: string }>({ a: isNumber })
-            // @ts-expect-error
             objectGuard<{ a: { b: string } }>({
+              // @ts-expect-error
               a: objectGuard({ b: isNumber }),
             })
-            // @ts-expect-error
             objectGuard<{ a: { b: string } }>({
+              // @ts-expect-error
               x: objectGuard({ y: isNumber }),
             })
           })

--- a/packages/pure-parse/src/guard/validation.ts
+++ b/packages/pure-parse/src/guard/validation.ts
@@ -260,7 +260,7 @@ export const partialRecord =
  * @param itemGuard validates every item in the array
  * @return a guard function that validates arrays
  */
-export const array =
+export const arrayGuard =
   <T>(itemGuard: Guard<T>): Guard<T[]> =>
   (data: unknown): data is T[] =>
     Array.isArray(data) && data.every(itemGuard)

--- a/packages/pure-parse/src/guard/validation.ts
+++ b/packages/pure-parse/src/guard/validation.ts
@@ -141,7 +141,7 @@ export const tuple =
 /**
  * Same as {@link objectGuard}, but does not perform just-in-time (JIT) compilation with the `Function` constructor. This function is needed as a replacement in environments where `new Function()` is disallowed; for example, when the [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) policy is set without the `'unsafe-eval`' directive.
  */
-export const objectGuardNoEval =
+export const objectGuardNoJit =
   <T extends Record<string, unknown>>(schema: {
     [K in keyof T]-?: {} extends Pick<T, K> ? OptionalGuard<T[K]> : Guard<T[K]>
   }) =>
@@ -182,8 +182,8 @@ export const objectGuard = <T extends Record<string, unknown>>(schema: {
   const guards = schemaEntries.map(([_, guard]) => guard)
   const body = [`return typeof data === 'object'`, `data !== null`]
     .concat(
-      schemaEntries.map(([unsanitizedKey, guardFunction], i) => {
-        const sanitizedKey = JSON.stringify(unsanitizedKey)
+      schemaEntries.map(([unescapedKey, guardFunction], i) => {
+        const sanitizedKey = JSON.stringify(unescapedKey)
         const value = `data[${sanitizedKey}]`
         const guard = `guards[${i}]`
         const isOptional = guardFunction[optionalSymbol] === true

--- a/packages/pure-parse/src/index.ts
+++ b/packages/pure-parse/src/index.ts
@@ -1,3 +1,9 @@
 export * from './common'
 export * from './parse'
-export { objectGuard, isString, isBoolean, isNumber } from './guard'
+export {
+  objectGuard,
+  objectGuardNoEval,
+  isString,
+  isBoolean,
+  isNumber,
+} from './guard'

--- a/packages/pure-parse/src/index.ts
+++ b/packages/pure-parse/src/index.ts
@@ -1,2 +1,3 @@
 export * from './common'
 export * from './parse'
+export { objectGuard, isString, isBoolean, isNumber } from './guard'

--- a/packages/pure-parse/src/index.ts
+++ b/packages/pure-parse/src/index.ts
@@ -2,7 +2,7 @@ export * from './common'
 export * from './parse'
 export {
   objectGuard,
-  objectGuardNoEval,
+  objectGuardNoJit,
   isString,
   isBoolean,
   isNumber,

--- a/packages/pure-parse/src/index.ts
+++ b/packages/pure-parse/src/index.ts
@@ -1,6 +1,7 @@
 export * from './common'
 export * from './parse'
 export {
+  arrayGuard,
   objectGuard,
   objectGuardNoJit,
   isString,

--- a/packages/pure-parse/src/parse/json.test.ts
+++ b/packages/pure-parse/src/parse/json.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseJson } from './json'
-import { object, isString, isNumber, isUnknown } from '../guard'
+import { objectGuard, isString, isNumber, isUnknown } from '../guard'
 
 describe('json', () => {
   describe('parseJson', () => {
@@ -17,7 +17,7 @@ describe('json', () => {
       expect(parseJson(isString)(JSON.stringify('abc'))).toEqual('abc')
       expect(parseJson(isNumber)(JSON.stringify(123))).toEqual(123)
       expect(
-        parseJson(object({ a: isNumber }))(JSON.stringify({ a: 1 })),
+        parseJson(objectGuard({ a: isNumber }))(JSON.stringify({ a: 1 })),
       ).toEqual({ a: 1 })
     })
   })

--- a/packages/pure-parse/src/parse/object.test.ts
+++ b/packages/pure-parse/src/parse/object.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest'
-import { object as objectParseEval, objectNoEval } from './object'
+import { object as objectParseEval, objectNoJit } from './object'
 import { isSuccess, Parser } from './types'
 import type { Equals } from '../internals'
 import { nullable, optional, union } from './union'
@@ -16,7 +16,7 @@ import { Infer } from '../common'
 const suits = [
   {
     name: 'objectNoEval',
-    fn: objectNoEval,
+    fn: objectNoJit,
   },
   {
     name: 'objectEval',

--- a/packages/pure-parse/src/parse/object.test.ts
+++ b/packages/pure-parse/src/parse/object.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from 'vitest'
 import { object } from './object'
-import { isSuccess } from './types'
+import { isSuccess, Parser } from './types'
 import type { Equals } from '../internals'
 import { nullable, optional } from './union'
 import { literal, parseBoolean, parseNumber, parseString } from './primitives'
@@ -306,5 +306,21 @@ describe('objects', () => {
       expect(result.value).not.toHaveProperty('__proto__')
     })
   })
-  describe.todo('self-referential objects')
+  describe('self-referential objects', () => {
+    // Type inferrence of recusive types are impossible in TypeScript
+    test('type declaration', () => {
+      type Tree = {
+        name: string
+        left?: Tree
+        right?: Tree
+      }
+
+      const parseTree: Parser<Tree> = (data) =>
+        object({
+          name: parseString,
+          left: optional(parseTree),
+          right: optional(parseTree),
+        })(data)
+    })
+  })
 })

--- a/packages/pure-parse/src/parse/object.test.ts
+++ b/packages/pure-parse/src/parse/object.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest'
-import { object } from './object'
+import { object as objectParseEval, objectNoEval } from './object'
 import { isSuccess, Parser } from './types'
 import type { Equals } from '../internals'
 import { nullable, optional, union } from './union'
@@ -13,335 +13,363 @@ import {
 import { fallback } from './fallback'
 import { Infer } from '../common'
 
-describe('objects', () => {
-  describe('unknown properties', () => {
-    it('excludes unknown properties', () => {
-      const parseObj = object({
-        expected: literal(true),
-      })
-      const data = { expected: true, unexpected: true }
-      expect(parseObj(data)).toEqual(
-        expect.objectContaining({
-          value: {
-            expected: true,
-          },
-        }),
-      )
-    })
-  })
-  describe('required properties', () => {
-    test('parsing', () => {
-      const parseUser = object({
-        id: parseNumber,
-        name: parseString,
-      })
-      expect(parseUser({ id: 1, name: 'Alice' })).toHaveProperty(
-        'tag',
-        'success',
-      )
-      expect(parseUser({ id: 1 })).toHaveProperty('tag', 'failure')
-      expect(parseUser({ name: 'Alice' })).toHaveProperty('tag', 'failure')
-      expect(parseUser({})).toHaveProperty('tag', 'failure')
-    })
-    describe('type annotation', () => {
-      type User = {
-        id: number
-        name: string
-      }
-      it('has a required parser', () => {
-        const parseUser1 = object<User>({
-          id: parseNumber,
-          name: parseString,
-        })
-      })
-      it('does not have an optional parser', () => {
-        const parseUser2 = object<User>({
-          id: parseNumber,
-          // @ts-expect-error -- required prop name must not be optional
-          name: optional(parseString),
-        })
-      })
-      it('must have a parser', () => {
-        const parseUser3 = object<User>(
-          // @ts-expect-error -- required prop name must not be omitted
-          {
-            id: parseNumber,
-          },
-        )
-      })
-    })
-    test('type inference', () => {
-      type User = {
-        id: number
-        email: string
-      }
-      const parseUser = object({
-        id: parseNumber,
-        email: parseString,
-      })
-      type InferredUser = Infer<typeof parseUser>
-      const T1: Equals<InferredUser, User> = true
-      const a1: InferredUser = {
-        id: 123,
-        email: '',
-      }
-      const a2: InferredUser = {
-        id: 123,
-        // @ts-expect-error -- wrong type of property
-        email: undefined,
-      }
-      // @ts-expect-error -- property is required
-      const a3: InferredUser = {
-        id: 123,
-      }
-    })
-  })
-  describe('required union properties', () => {
-    test('parsing', () => {
-      const parseUser = object({
-        id: parseNumber,
-        email: nullable(parseString),
-      })
-      expect(parseUser({ id: 1, email: null })).toHaveProperty('tag', 'success')
-      expect(parseUser({ id: 1, email: 'alice@test.com' })).toHaveProperty(
-        'tag',
-        'success',
-      )
-      expect(parseUser({ id: 1, email: 123 })).toHaveProperty('tag', 'failure')
-      expect(parseUser({ id: 1 })).toHaveProperty('tag', 'failure')
-      expect(parseUser({})).toHaveProperty('tag', 'failure')
-    })
-  })
-  describe('optional properties', () => {
-    it('differentiates between undefined and missing properties', () => {
-      const parseOptionalObj = object({
-        a: optional(parseString),
-      })
-      expect(parseOptionalObj({})).toHaveProperty('tag', 'success')
-      expect(parseOptionalObj({ a: undefined })).toHaveProperty(
-        'tag',
-        'success',
-      )
-      const parseUnionObj = object({
-        a: union(parseString, parseUndefined),
-      })
-      expect(parseUnionObj({})).toHaveProperty('tag', 'failure')
-      expect(parseUnionObj({ a: undefined })).toHaveProperty('tag', 'success')
-    })
-    test('parsing', () => {
-      const parseUser = object({
-        id: parseNumber,
-        email: optional(parseString),
-      })
-      expect(isSuccess(parseUser({ id: 1 }))).toEqual(true)
-      expect(parseUser({ id: 1, email: undefined })).toHaveProperty(
-        'tag',
-        'success',
-      )
-      expect(parseUser({ id: 1, email: 'alice@test.com' })).toHaveProperty(
-        'tag',
-        'success',
-      )
-      expect(parseUser({ id: 1, email: 123 })).toHaveProperty('tag', 'failure')
-      expect(parseUser({})).toHaveProperty('tag', 'failure')
-    })
-    describe('type annotation', () => {
-      type User = {
-        id: number
-        email?: string
-      }
-      it('has an optional parser', () => {
-        const parseUser1 = object<User>({
-          id: parseNumber,
-          email: optional(parseString),
-        })
-      })
-      it('can not have a required parser', () => {
-        const parseUser1 = object<User>({
-          id: parseNumber,
-          // a required string is a subset of optional string
-          email: parseString,
-        })
-      })
-      it('does have a parser', () => {
-        const parseUser3 = object<User>(
-          // @ts-expect-error -- email parser must be present even though the property is optional
-          {
-            id: parseNumber,
-          },
-        )
-      })
-    })
-    test('optional optional properties', () => {
-      const parseUser = object({
-        id: parseNumber,
-        email: optional(optional(parseString)),
-      })
-    })
-    test('type inference', () => {
-      type User = {
-        id: number
-        email?: string
-      }
-      const parseUser = object({
-        id: parseNumber,
-        email: optional(parseString),
-      })
-      type InferredUser = Infer<typeof parseUser>
-      // @ts-expect-error -- TODO can't get this to work
-      const T1: Equals<InferredUser, User> = true
-      const a1: InferredUser = {
-        id: 123,
-        email: '',
-      }
-      const a2: InferredUser = {
-        id: 123,
-        email: undefined,
-      }
-      // @ts-expect-error -- TODO can't get this to work
-      const a3: InferredUser = {
-        id: 123,
-      }
-    })
-  })
-  describe('fallback', () => {
-    test('optional fallback', () => {
-      const defaultEmail = 'default@test.com'
-      const parseUser = object({
-        id: parseNumber,
-        name: parseString,
-        email: optional(fallback(parseString, defaultEmail)),
-      })
-      // The email can be a omitted -> Success
-      expect(parseUser({ id: 1, name: 'Alice' })).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice' },
-        }),
-      )
+const suits = [
+  {
+    name: 'objectNoEval',
+    fn: objectNoEval,
+  },
+  {
+    name: 'objectEval',
+    fn: objectParseEval,
+  },
+  //   TODO objectMemo
+]
 
-      // The email can be a string -> Success
-      expect(
-        parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
-      ).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice', email: 'alice@test.com' },
-        }),
-      )
-
-      // The email can't be a number -> falls back
-      expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice', email: defaultEmail },
-        }),
-      )
-    })
-    it('excludes unknown properties', () => {
-      const parseUser = object({
-        id: parseNumber,
+suits.forEach(({ name: suiteName, fn: object }) => {
+  describe(suiteName, () => {
+    describe('objects', () => {
+      describe('unknown properties', () => {
+        it('excludes unknown properties', () => {
+          const parseObj = object({
+            expected: literal(true),
+          })
+          const data = { expected: true, unexpected: true }
+          expect(parseObj(data)).toEqual(
+            expect.objectContaining({
+              value: {
+                expected: true,
+              },
+            }),
+          )
+        })
       })
-      const data = {
-        id: 123,
-        unexpected: true,
-      }
-      expect(parseUser(data)).toEqual(
-        expect.objectContaining({
-          value: {
+      describe('required properties', () => {
+        test('parsing', () => {
+          const parseUser = object({
+            id: parseNumber,
+            name: parseString,
+          })
+          expect(parseUser({ id: 1, name: 'Alice' })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          expect(parseUser({ id: 1 })).toHaveProperty('tag', 'failure')
+          expect(parseUser({ name: 'Alice' })).toHaveProperty('tag', 'failure')
+          expect(parseUser({})).toHaveProperty('tag', 'failure')
+        })
+        describe('type annotation', () => {
+          type User = {
+            id: number
+            name: string
+          }
+          it('has a required parser', () => {
+            const parseUser1 = object<User>({
+              id: parseNumber,
+              name: parseString,
+            })
+          })
+          it('does not have an optional parser', () => {
+            const parseUser2 = object<User>({
+              id: parseNumber,
+              // @ts-expect-error -- required prop name must not be optional
+              name: optional(parseString),
+            })
+          })
+          it('must have a parser', () => {
+            const parseUser3 = object<User>(
+              // @ts-expect-error -- required prop name must not be omitted
+              {
+                id: parseNumber,
+              },
+            )
+          })
+        })
+        test('type inference', () => {
+          type User = {
+            id: number
+            email: string
+          }
+          const parseUser = object({
+            id: parseNumber,
+            email: parseString,
+          })
+          type InferredUser = Infer<typeof parseUser>
+          const T1: Equals<InferredUser, User> = true
+          const a1: InferredUser = {
             id: 123,
-          },
-        }),
-      )
-    })
-    test('required fallback', () => {
-      const defaultEmail = 'default@test.com'
-      const parseUser = object({
-        id: parseNumber,
-        name: parseString,
-        email: fallback(parseString, defaultEmail),
+            email: '',
+          }
+          const a2: InferredUser = {
+            id: 123,
+            // @ts-expect-error -- wrong type of property
+            email: undefined,
+          }
+          // @ts-expect-error -- property is required
+          const a3: InferredUser = {
+            id: 123,
+          }
+        })
       })
-
-      // The property can be a string -> Success
-      expect(
-        parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
-      ).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice', email: 'alice@test.com' },
-        }),
-      )
-
-      // number fails -> Falls back
-      expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice', email: defaultEmail },
-        }),
-      )
-
-      // The property is required -> Fails
-      expect(parseUser({ id: 1, name: 'Alice' })).toHaveProperty(
-        'tag',
-        'failure',
-      )
-    })
-  })
-  describe('prototype pollution', () => {
-    it('prevents prototype pollution', () => {
-      const parseUser = object({
-        id: parseNumber,
-        name: parseString,
+      describe('required union properties', () => {
+        test('parsing', () => {
+          const parseUser = object({
+            id: parseNumber,
+            email: nullable(parseString),
+          })
+          expect(parseUser({ id: 1, email: null })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          expect(parseUser({ id: 1, email: 'alice@test.com' })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          expect(parseUser({ id: 1, email: 123 })).toHaveProperty(
+            'tag',
+            'failure',
+          )
+          expect(parseUser({ id: 1 })).toHaveProperty('tag', 'failure')
+          expect(parseUser({})).toHaveProperty('tag', 'failure')
+        })
       })
-      const data = JSON.parse(
-        '{"__proto__": {"isAdmin": true}, "id": 1, "name": "Alice"}',
-      )
-      const result = parseUser(data)
-      if (result.tag === 'failure') {
-        throw new Error('Expected success')
-      }
-      expect(result).toEqual(
-        expect.objectContaining({
-          value: { id: 1, name: 'Alice' },
-        }),
-      )
-      expect(result.value).not.toHaveProperty('isAdmin')
-      expect(result.value).not.toHaveProperty('__proto__')
-
-      // Without parsing, prototype pollution can happen
-      expect(Object.assign({}, data)).toHaveProperty('isAdmin')
-      // After parsing, the prototype pollution is impossible
-      expect(Object.assign({}, result.value)).not.toHaveProperty('isAdmin')
-    })
-    it('allows you to shoot yourself in the foot, if you really want it', () => {
-      const parseUser = object({
-        id: parseNumber,
-        name: parseString,
-        ['__proto__']: object({
-          isAdmin: parseBoolean,
-        }),
+      describe('optional properties', () => {
+        it('differentiates between undefined and missing properties', () => {
+          const parseOptionalObj = object({
+            a: optional(parseString),
+          })
+          expect(parseOptionalObj({})).toHaveProperty('tag', 'success')
+          expect(parseOptionalObj({ a: undefined })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          const parseUnionObj = object({
+            a: union(parseString, parseUndefined),
+          })
+          expect(parseUnionObj({})).toHaveProperty('tag', 'failure')
+          expect(parseUnionObj({ a: undefined })).toHaveProperty(
+            'tag',
+            'success',
+          )
+        })
+        test('parsing', () => {
+          const parseUser = object({
+            id: parseNumber,
+            email: optional(parseString),
+          })
+          expect(isSuccess(parseUser({ id: 1 }))).toEqual(true)
+          expect(parseUser({ id: 1, email: undefined })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          expect(parseUser({ id: 1, email: 'alice@test.com' })).toHaveProperty(
+            'tag',
+            'success',
+          )
+          expect(parseUser({ id: 1, email: 123 })).toHaveProperty(
+            'tag',
+            'failure',
+          )
+          expect(parseUser({})).toHaveProperty('tag', 'failure')
+        })
+        describe('type annotation', () => {
+          type User = {
+            id: number
+            email?: string
+          }
+          it('has an optional parser', () => {
+            const parseUser1 = object<User>({
+              id: parseNumber,
+              email: optional(parseString),
+            })
+          })
+          it('can not have a required parser', () => {
+            const parseUser1 = object<User>({
+              id: parseNumber,
+              // a required string is a subset of optional string
+              email: parseString,
+            })
+          })
+          it('does have a parser', () => {
+            const parseUser3 = object<User>(
+              // @ts-expect-error -- email parser must be present even though the property is optional
+              {
+                id: parseNumber,
+              },
+            )
+          })
+        })
+        test('optional optional properties', () => {
+          const parseUser = object({
+            id: parseNumber,
+            email: optional(optional(parseString)),
+          })
+        })
+        test('type inference', () => {
+          type User = {
+            id: number
+            email?: string
+          }
+          const parseUser = object({
+            id: parseNumber,
+            email: optional(parseString),
+          })
+          type InferredUser = Infer<typeof parseUser>
+          // @ts-expect-error -- TODO can't get this to work
+          const T1: Equals<InferredUser, User> = true
+          const a1: InferredUser = {
+            id: 123,
+            email: '',
+          }
+          const a2: InferredUser = {
+            id: 123,
+            email: undefined,
+          }
+          // @ts-expect-error -- TODO can't get this to work
+          const a3: InferredUser = {
+            id: 123,
+          }
+        })
       })
-      const data = JSON.parse(
-        '{"__proto__": {"isAdmin": true}, "id": 1, "name": "Alice"}',
-      )
-      const result = parseUser(data)
-      if (result.tag === 'failure') {
-        throw new Error('Expected success')
-      }
-      expect(result.value).toHaveProperty('isAdmin')
-      expect(result.value).not.toHaveProperty('__proto__')
-    })
-  })
-  describe('self-referential objects', () => {
-    // Type inferrence of recusive types are impossible in TypeScript
-    test('type declaration', () => {
-      type Tree = {
-        name: string
-        left?: Tree
-        right?: Tree
-      }
+      describe('fallback', () => {
+        test('optional fallback', () => {
+          const defaultEmail = 'default@test.com'
+          const parseUser = object({
+            id: parseNumber,
+            name: parseString,
+            email: optional(fallback(parseString, defaultEmail)),
+          })
+          // The email can be a omitted -> Success
+          expect(parseUser({ id: 1, name: 'Alice' })).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice' },
+            }),
+          )
 
-      const parseTree: Parser<Tree> = (data) =>
-        object({
-          name: parseString,
-          left: optional(parseTree),
-          right: optional(parseTree),
-        })(data)
+          // The email can be a string -> Success
+          expect(
+            parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
+          ).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice', email: 'alice@test.com' },
+            }),
+          )
+
+          // The email can't be a number -> falls back
+          expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice', email: defaultEmail },
+            }),
+          )
+        })
+        it('excludes unknown properties', () => {
+          const parseUser = object({
+            id: parseNumber,
+          })
+          const data = {
+            id: 123,
+            unexpected: true,
+          }
+          expect(parseUser(data)).toEqual(
+            expect.objectContaining({
+              value: {
+                id: 123,
+              },
+            }),
+          )
+        })
+        test('required fallback', () => {
+          const defaultEmail = 'default@test.com'
+          const parseUser = object({
+            id: parseNumber,
+            name: parseString,
+            email: fallback(parseString, defaultEmail),
+          })
+
+          // The property can be a string -> Success
+          expect(
+            parseUser({ id: 1, name: 'Alice', email: 'alice@test.com' }),
+          ).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice', email: 'alice@test.com' },
+            }),
+          )
+
+          // number fails -> Falls back
+          expect(parseUser({ id: 1, name: 'Alice', email: 123 })).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice', email: defaultEmail },
+            }),
+          )
+
+          // The property is required -> Fails
+          expect(parseUser({ id: 1, name: 'Alice' })).toHaveProperty(
+            'tag',
+            'failure',
+          )
+        })
+      })
+      describe('prototype pollution', () => {
+        it('prevents prototype pollution', () => {
+          const parseUser = object({
+            id: parseNumber,
+            name: parseString,
+          })
+          const data = JSON.parse(
+            '{"__proto__": {"isAdmin": true}, "id": 1, "name": "Alice"}',
+          )
+          const result = parseUser(data)
+          if (result.tag === 'failure') {
+            throw new Error('Expected success')
+          }
+          expect(result).toEqual(
+            expect.objectContaining({
+              value: { id: 1, name: 'Alice' },
+            }),
+          )
+          expect(result.value).not.toHaveProperty('isAdmin')
+          expect(result.value).not.toHaveProperty('__proto__')
+
+          // Without parsing, prototype pollution can happen
+          expect(Object.assign({}, data)).toHaveProperty('isAdmin')
+          // After parsing, the prototype pollution is impossible
+          expect(Object.assign({}, result.value)).not.toHaveProperty('isAdmin')
+        })
+        it('allows you to shoot yourself in the foot, if you really want it', () => {
+          const parseUser = object({
+            id: parseNumber,
+            name: parseString,
+            ['__proto__']: object({
+              isAdmin: parseBoolean,
+            }),
+          })
+          const data = JSON.parse(
+            '{"__proto__": {"isAdmin": true}, "id": 1, "name": "Alice"}',
+          )
+          const result = parseUser(data)
+          if (result.tag === 'failure') {
+            throw new Error('Expected success')
+          }
+          expect(result.value).toHaveProperty('isAdmin')
+          expect(result.value).not.toHaveProperty('__proto__')
+        })
+      })
+      describe('self-referential objects', () => {
+        // Type inferrence of recusive types are impossible in TypeScript
+        test('type declaration', () => {
+          type Tree = {
+            name: string
+            left?: Tree
+            right?: Tree
+          }
+
+          const parseTree: Parser<Tree> = (data) =>
+            object({
+              name: parseString,
+              left: optional(parseTree),
+              right: optional(parseTree),
+            })(data)
+        })
+      })
     })
   })
 })

--- a/packages/pure-parse/src/parse/object.test.ts
+++ b/packages/pure-parse/src/parse/object.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it, test } from 'vitest'
 import { object } from './object'
 import { isSuccess, Parser } from './types'
 import type { Equals } from '../internals'
-import { nullable, optional } from './union'
-import { literal, parseBoolean, parseNumber, parseString } from './primitives'
+import { nullable, optional, union } from './union'
+import {
+  literal,
+  parseBoolean,
+  parseNumber,
+  parseString,
+  parseUndefined,
+} from './primitives'
 import { fallback } from './fallback'
 import { Infer } from '../common'
 
@@ -107,6 +113,21 @@ describe('objects', () => {
     })
   })
   describe('optional properties', () => {
+    it('differentiates between undefined and missing properties', () => {
+      const parseOptionalObj = object({
+        a: optional(parseString),
+      })
+      expect(parseOptionalObj({})).toHaveProperty('tag', 'success')
+      expect(parseOptionalObj({ a: undefined })).toHaveProperty(
+        'tag',
+        'success',
+      )
+      const parseUnionObj = object({
+        a: union(parseString, parseUndefined),
+      })
+      expect(parseUnionObj({})).toHaveProperty('tag', 'failure')
+      expect(parseUnionObj({ a: undefined })).toHaveProperty('tag', 'success')
+    })
     test('parsing', () => {
       const parseUser = object({
         id: parseNumber,

--- a/packages/pure-parse/src/parse/object.ts
+++ b/packages/pure-parse/src/parse/object.ts
@@ -12,7 +12,7 @@ import { optionalSymbol } from '../internals'
 /**
  * Same as {@link object}, but does not perform just-in-time (JIT) compilation with the `Function` constructor. This function is needed as a replacement in environments where `new Function()` is disallowed; for example, when the [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) policy is set without the `'unsafe-eval`' directive.
  */
-export const objectNoEval = <T extends Record<string, unknown>>(schema: {
+export const objectNoJit = <T extends Record<string, unknown>>(schema: {
   // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
   [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>
 }): Parser<T> => {
@@ -67,8 +67,8 @@ export const object = <T extends Record<string, unknown>>(schema: {
     `if(typeof data !== 'object' || data === null) return {tag:'failure', message:'Not an object'}`,
     `const dataOutput = {}`,
     `let parseResult`,
-    ...schemaEntries.flatMap(([unsanitizedKey, parserFunction], i) => {
-      const key = JSON.stringify(unsanitizedKey)
+    ...schemaEntries.flatMap(([unescapedKey, parserFunction], i) => {
+      const key = JSON.stringify(unescapedKey)
       // 2% faster to inline the value and parser, rather than look up once and use a variable
       // 12% faster to inline failure and success object creations
       const value = `data[${key}]`

--- a/packages/pure-parse/src/parse/object.ts
+++ b/packages/pure-parse/src/parse/object.ts
@@ -21,35 +21,77 @@ import { optionalSymbol } from '../internals'
  * @param schema maps keys to validation functions.
  * @return a parser function that validates objects according to `schema`.
  */
+// export const object = <T extends Record<string, unknown>>(schema: {
+//   // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
+//   [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>
+// }): Parser<T> => {
+//   const entries = Object.entries(schema)
+//   return (data) => {
+//     if (!isObject(data)) {
+//       return failure('Not an object')
+//     }
+//     const dataOutput = {} as Record<string, unknown>
+//     for (let i = 0; i < entries.length; i++) {
+//       const [key, parser] = entries[i]!
+//       const value = (data as Record<string, unknown>)[key]
+//       // Perf: only check if the property exists the value is undefined => huge performance boost
+//       if (value === undefined && !data.hasOwnProperty(key)) {
+//         if (parser[optionalSymbol] === true) {
+//           // The key is optional, so we can skip it
+//           continue
+//         }
+//         return failure('A property is missing')
+//       }
+//
+//       const parseResult = parser(value)
+//       if (parseResult.tag === 'failure') {
+//         return failure('Not all properties are valid')
+//       }
+//       dataOutput[key] = (parseResult as ParseSuccess<unknown>).value
+//     }
+//
+//     return success(dataOutput) as ParseResult<T>
+//   }
+// }
+
 export const object = <T extends Record<string, unknown>>(schema: {
   // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
   [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>
 }): Parser<T> => {
-  const entries = Object.entries(schema)
-  return (data) => {
-    if (!isObject(data)) {
-      return failure('Not an object')
-    }
-    const dataOutput = {} as Record<string, unknown>
-    for (let i = 0; i < entries.length; i++) {
-      const [key, parser] = entries[i]!
-      const value = (data as Record<string, unknown>)[key]
-      // Perf: only check if the property exists the value is undefined => huge performance boost
-      if (value === undefined && !data.hasOwnProperty(key)) {
-        if (parser[optionalSymbol] === true) {
-          // The key is optional, so we can skip it
-          continue
-        }
-        return failure('A property is missing')
-      }
+  const schemaEntries = Object.entries(schema)
+  const parsers = schemaEntries.map(([_, parser]) => parser)
+  const statements = [
+    `if(typeof data !== 'object' || data === null) return failure('Not an object')`,
+    `const dataOutput = {}`,
+    `let value`,
+    `let parser`,
+    `let parseResult`,
+    ...schemaEntries.flatMap(([key], i) => {
+      const sanitizedKey = JSON.stringify(key)
+      return [
+        `value = data[${sanitizedKey}]`,
+        `parser = parsers[${i}]`,
+        `if(value === undefined && !data.hasOwnProperty(${sanitizedKey})) {`,
+        `if(parser[optionalSymbol] !== true) return failure('A property is missing')`,
+        `} else {`,
+        `parseResult = parser(value)`,
+        `if(parseResult.tag === 'failure') return failure('Not all properties are valid')`,
+        `dataOutput[${sanitizedKey}] = parseResult.value`,
+        `}`,
+      ]
+    }),
+    `return success(dataOutput)`,
+  ]
+  const body = statements.join(';')
+  const fun = new Function(
+    'data',
+    'optionalSymbol',
+    'parsers',
+    'success',
+    'failure',
+    body,
+  )
 
-      const parseResult = parser(value)
-      if (parseResult.tag === 'failure') {
-        return failure('Not all properties are valid')
-      }
-      dataOutput[key] = (parseResult as ParseSuccess<unknown>).value
-    }
-
-    return success(dataOutput) as ParseResult<T>
-  }
+  return (data: unknown): ParseResult<T> =>
+    fun(data, optionalSymbol, parsers, success, failure)
 }

--- a/packages/pure-parse/src/parse/object.ts
+++ b/packages/pure-parse/src/parse/object.ts
@@ -10,6 +10,42 @@ import {
 import { optionalSymbol } from '../internals'
 
 /**
+ * Same as {@link object}, but does not perform just-in-time (JIT) compilation with the `Function` constructor. This function is needed as a replacement in environments where `new Function()` is disallowed; for example, when the [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) policy is set without the `'unsafe-eval`' directive.
+ */
+export const objectNoEval = <T extends Record<string, unknown>>(schema: {
+  // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
+  [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>
+}): Parser<T> => {
+  const entries = Object.entries(schema)
+  return (data) => {
+    if (!isObject(data)) {
+      return failure('Not an object')
+    }
+    const dataOutput = {} as Record<string, unknown>
+    for (let i = 0; i < entries.length; i++) {
+      const [key, parser] = entries[i]!
+      const value = (data as Record<string, unknown>)[key]
+      // Perf: only check if the property exists the value is undefined => huge performance boost
+      if (value === undefined && !data.hasOwnProperty(key)) {
+        if (parser[optionalSymbol] === true) {
+          // The key is optional, so we can skip it
+          continue
+        }
+        return failure('A property is missing')
+      }
+
+      const parseResult = parser(value)
+      if (parseResult.tag === 'failure') {
+        return failure('Not all properties are valid')
+      }
+      dataOutput[key] = (parseResult as ParseSuccess<unknown>).value
+    }
+
+    return success(dataOutput) as ParseResult<T>
+  }
+}
+
+/**
  * Objects have a fixed set of properties that can have different types.
  * @example
  * const parseUser = object({
@@ -21,39 +57,6 @@ import { optionalSymbol } from '../internals'
  * @param schema maps keys to validation functions.
  * @return a parser function that validates objects according to `schema`.
  */
-// export const object = <T extends Record<string, unknown>>(schema: {
-//   // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
-//   [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>
-// }): Parser<T> => {
-//   const entries = Object.entries(schema)
-//   return (data) => {
-//     if (!isObject(data)) {
-//       return failure('Not an object')
-//     }
-//     const dataOutput = {} as Record<string, unknown>
-//     for (let i = 0; i < entries.length; i++) {
-//       const [key, parser] = entries[i]!
-//       const value = (data as Record<string, unknown>)[key]
-//       // Perf: only check if the property exists the value is undefined => huge performance boost
-//       if (value === undefined && !data.hasOwnProperty(key)) {
-//         if (parser[optionalSymbol] === true) {
-//           // The key is optional, so we can skip it
-//           continue
-//         }
-//         return failure('A property is missing')
-//       }
-//
-//       const parseResult = parser(value)
-//       if (parseResult.tag === 'failure') {
-//         return failure('Not all properties are valid')
-//       }
-//       dataOutput[key] = (parseResult as ParseSuccess<unknown>).value
-//     }
-//
-//     return success(dataOutput) as ParseResult<T>
-//   }
-// }
-
 export const object = <T extends Record<string, unknown>>(schema: {
   // When you pick K from T, do you get an object with an optional property, which {} can be assigned to?
   [K in keyof T]-?: {} extends Pick<T, K> ? OptionalParser<T[K]> : Parser<T[K]>

--- a/packages/test-app/src/guard.ts
+++ b/packages/test-app/src/guard.ts
@@ -1,4 +1,4 @@
-import { array, isNumber, object, isJsonValue } from 'pure-parse/guard'
+import { arrayGuard, isNumber, objectGuard } from 'pure-parse'
 
 /**
  * Just for CI/CD testing: the actual UI doesn't matter
@@ -6,7 +6,6 @@ import { array, isNumber, object, isJsonValue } from 'pure-parse/guard'
 
 export const guardTests = [
   ['isNumber(1)', isNumber(1)],
-  ['object({ a: isNumber })({ a: 1 })', object({ a: isNumber })({ a: 1 })],
-  ['array(isNumber)([1,2,3])', array(isNumber)([1, 2, 3])],
-  ['isJsonValue({ a: 1 })', isJsonValue({ a: 1 })],
+  ['object({ a: isNumber })({ a: 1 })', objectGuard({ a: isNumber })({ a: 1 })],
+  ['array(isNumber)([1,2,3])', arrayGuard(isNumber)([1, 2, 3])],
 ]


### PR DESCRIPTION
## What?

Increase performance of the object validator functions:

- `object` by 7×
- `objectGuard` by 18×

As measured on MacBook Pro:

Chip: Apple M1 Pro
Memory: 16 GB

For unsafe validation:

| Function           | Mops/s | Relative to PureParse |
| ------------------ | ------ | --------------------- |
| PureParse          | 74.4   | 100%                  |
| PureParse (before) | 4.1    | 5.5%                  |
| Zod                | 1.1    | 1.4%                  |
| io-ts              | 3.5    | 4.7%                  |
| Ajv                | 49     | 65%                   |
| Yup                | 84     | 120%                  |
| Typia              | 101    | 136%                  |
| ts-runtime-checks  | 102    | 137%                  |

For safe parsing:

| Function           | Mops/s | Relative to PureParse |
| ------------------ | ------ | --------------------- |
| PureParse          | 28.9   | 100%                  |
| PureParse (before) | 4.1    | 14%                   |


Summary

- increased performance of the unsafe evals by a few percentage points
- added docs on performance and security
- the new JIT functions replace the old functions.
- The old functions are exported as `objectNoJit` and `objectGuardNoJit`

Only the object functions benefit enough to justify the usage of JIT.

## Why?

With performance being improved with JIT, there will be one less reason to not pick PureParse.

