### PR TITLE
refactor: rename guard functions

### DIFF
--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -36,11 +36,6 @@
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./guard": {
-      "require": "./dist/index.cjs",
-      "types": "./dist/guard/index.d.ts",
-      "import": "./dist/guard/index.js"
     }
   },
   "scripts": {

--- a/packages/pure-parse/src/guard/README.test.ts
+++ b/packages/pure-parse/src/guard/README.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { isString } from './primitives'
 import { Guard } from './types'
-import { literal } from './literal'
-import { union } from './union'
+import { literalGuard } from './literal'
+import { unionGuard } from './union'
 import { objectGuard } from './object'
 import { arrayGuard } from './arrays'
 
@@ -17,18 +17,18 @@ describe('README examples', () => {
       <T>(guard: Guard<T>) =>
       (data: unknown): data is Leaf<T> =>
         objectGuard({
-          tag: literal('leaf'),
+          tag: literalGuard('leaf'),
           data: guard,
         })(data)
 
     const tree =
       <T>(guard: Guard<T>) =>
       (data: unknown): data is Tree<T> =>
-        union(
+        unionGuard(
           leaf(guard),
           objectGuard({
-            tag: literal('tree'),
-            data: arrayGuard(union(leaf(guard), tree(guard))),
+            tag: literalGuard('tree'),
+            data: arrayGuard(unionGuard(leaf(guard), tree(guard))),
           }),
         )(data)
     describe('leaf', () => {

--- a/packages/pure-parse/src/guard/arrays.test.ts
+++ b/packages/pure-parse/src/guard/arrays.test.ts
@@ -10,7 +10,7 @@ import {
 import { Guard } from './types'
 import { Infer } from '../common'
 import { Equals } from '../internals'
-import { union } from './union'
+import { unionGuard } from './union'
 
 describe('arrays', () => {
   describe('types', () => {
@@ -34,9 +34,9 @@ describe('arrays', () => {
     test('explicit generic type annotation', () => {
       arrayGuard<number>(isNumber)
       arrayGuard<string>(isString)
-      arrayGuard<string | number>(union(isString, isNumber))
+      arrayGuard<string | number>(unionGuard(isString, isNumber))
       // @ts-expect-error
-      arrayGuard<number>(union(isString, isNumber))
+      arrayGuard<number>(unionGuard(isString, isNumber))
       // @ts-expect-error
       arrayGuard<string>(isNumber)
       // @ts-expect-error
@@ -88,10 +88,10 @@ describe('arrays', () => {
     )
   })
   it('expects every element to pass the validation', () => {
-    expect(arrayGuard(union(isNumber))([1, 2, 3, 4])).toEqual(true)
-    expect(arrayGuard(union(isNumber))([1, 2, 3, 'a', 4])).toEqual(false)
+    expect(arrayGuard(unionGuard(isNumber))([1, 2, 3, 4])).toEqual(true)
+    expect(arrayGuard(unionGuard(isNumber))([1, 2, 3, 'a', 4])).toEqual(false)
     expect(
-      arrayGuard(union(isString, isNumber, isBoolean))([1, 'a', false]),
+      arrayGuard(unionGuard(isString, isNumber, isBoolean))([1, 'a', false]),
     ).toEqual(true)
   })
 })

--- a/packages/pure-parse/src/guard/json.ts
+++ b/packages/pure-parse/src/guard/json.ts
@@ -1,15 +1,15 @@
 import { isBoolean, isNull, isNumber, isString } from './primitives'
 import { JsonValue } from '../common'
-import { union } from './union'
-import { partialRecord } from './records'
+import { unionGuard } from './union'
+import { partialRecordGuard } from './records'
 import { arrayGuard } from './arrays'
 
 export const isJsonValue = (data: unknown): data is JsonValue =>
-  union(
+  unionGuard(
     isNull,
     isBoolean,
     isNumber,
     isString,
-    partialRecord(isString, isJsonValue),
+    partialRecordGuard(isString, isJsonValue),
     arrayGuard(isJsonValue),
   )(data)

--- a/packages/pure-parse/src/guard/literal.test.ts
+++ b/packages/pure-parse/src/guard/literal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest'
-import { literal } from './literal'
+import { literalGuard } from './literal'
 import { Guard } from './types'
 
 describe('literal types', () => {
@@ -7,45 +7,45 @@ describe('literal types', () => {
     describe('type inference', () => {
       it('works with literals', () => {
         const symb = Symbol()
-        literal(symb) satisfies Guard<typeof symb>
-        literal('red') satisfies Guard<'red'>
+        literalGuard(symb) satisfies Guard<typeof symb>
+        literalGuard('red') satisfies Guard<'red'>
         // @ts-expect-error
-        literal('red') satisfies Guard<'green'>
-        literal(1) satisfies Guard<1>
+        literalGuard('red') satisfies Guard<'green'>
+        literalGuard(1) satisfies Guard<1>
         // @ts-expect-error
-        literal(1) satisfies Guard<2>
+        literalGuard(1) satisfies Guard<2>
       })
       it('forbids non-literals', () => {
         // @ts-expect-error
-        literal([])
+        literalGuard([])
         // @ts-expect-error
-        literal({})
+        literalGuard({})
       })
     })
     describe('explicit generic type annotation', () => {
       it('works with literals', () => {
-        literal<['red']>('red')
+        literalGuard<['red']>('red')
         // @ts-expect-error
-        literal<['green']>('red')
+        literalGuard<['green']>('red')
 
-        literal<[1]>(1)
+        literalGuard<[1]>(1)
         // @ts-expect-error
-        literal<[1]>(2)
+        literalGuard<[1]>(2)
 
         // @ts-expect-error
-        literal<['1']>(1)
+        literalGuard<['1']>(1)
       })
     })
   })
   describe('unions of literals', () => {
     it('validates unions of literals correctly', () => {
-      const isColor = literal('red', 'green', 'blue')
+      const isColor = literalGuard('red', 'green', 'blue')
       expect(isColor('red')).toEqual(true)
       expect(isColor('green')).toEqual(true)
       expect(isColor('blue')).toEqual(true)
       expect(isColor('music')).toEqual(false)
 
-      const isInUnion = literal('red', 1, true)
+      const isInUnion = literalGuard('red', 1, true)
       expect(isInUnion('red')).toEqual(true)
       expect(isInUnion('green')).toEqual(false)
       expect(isInUnion(1)).toEqual(true)
@@ -54,43 +54,45 @@ describe('literal types', () => {
       expect(isInUnion(false)).toEqual(false)
     })
     it('infers the types of unions of literals', () => {
-      literal('red', 1, true) satisfies Guard<'red' | 1 | true>
-      literal('red', 'green', 'blue') satisfies Guard<'red' | 'green' | 'blue'>
+      literalGuard('red', 1, true) satisfies Guard<'red' | 1 | true>
+      literalGuard('red', 'green', 'blue') satisfies Guard<
+        'red' | 'green' | 'blue'
+      >
       // @ts-expect-error
-      literal('red', 'green', 'blue') satisfies Guard<'red'>
+      literalGuard('red', 'green', 'blue') satisfies Guard<'red'>
     })
     test('explicit type annotation', () => {
-      literal<['red', 'green', 'blue']>('red', 'green', 'blue')
+      literalGuard<['red', 'green', 'blue']>('red', 'green', 'blue')
       // @ts-expect-error
-      literal<['red', 'green', 'blue']>('red')
+      literalGuard<['red', 'green', 'blue']>('red')
       // @ts-expect-error
-      literal<['red', 'green', 'blue']>('red', 'green', 'blue', 'music')
+      literalGuard<['red', 'green', 'blue']>('red', 'green', 'blue', 'music')
     })
   })
   describe('literal', () => {
     it('matches null', () => {
-      expect(literal(null)(null)).toEqual(true)
+      expect(literalGuard(null)(null)).toEqual(true)
     })
     it('matches undefined', () => {
-      expect(literal(undefined)(undefined)).toEqual(true)
+      expect(literalGuard(undefined)(undefined)).toEqual(true)
     })
     it('matches strings', () => {
-      expect(literal('')('')).toEqual(true)
-      expect(literal('a')('a')).toEqual(true)
-      expect(literal('abc')('123')).toEqual(false)
+      expect(literalGuard('')('')).toEqual(true)
+      expect(literalGuard('a')('a')).toEqual(true)
+      expect(literalGuard('abc')('123')).toEqual(false)
     })
     it('matches numbers', () => {
-      expect(literal(-1)(-1)).toEqual(true)
-      expect(literal(0)(0)).toEqual(true)
-      expect(literal(1)(1)).toEqual(true)
+      expect(literalGuard(-1)(-1)).toEqual(true)
+      expect(literalGuard(0)(0)).toEqual(true)
+      expect(literalGuard(1)(1)).toEqual(true)
 
-      expect(literal(123)('123')).toEqual(false)
+      expect(literalGuard(123)('123')).toEqual(false)
     })
     it('matches booleans', () => {
-      expect(literal(true)(true)).toEqual(true)
-      expect(literal(false)(false)).toEqual(true)
-      expect(literal(true)(false)).toEqual(false)
-      expect(literal(false)(true)).toEqual(false)
+      expect(literalGuard(true)(true)).toEqual(true)
+      expect(literalGuard(false)(false)).toEqual(true)
+      expect(literalGuard(true)(false)).toEqual(false)
+      expect(literalGuard(false)(true)).toEqual(false)
     })
   })
 })

--- a/packages/pure-parse/src/guard/literal.ts
+++ b/packages/pure-parse/src/guard/literal.ts
@@ -24,7 +24,7 @@ import { Guard } from './types'
  * ```
  * @param constants compared against `data` with the `===` operator.
  */
-export const literal =
+export const literalGuard =
   <const T extends readonly [...Primitive[]]>(
     ...constants: T
   ): Guard<T[number]> =>

--- a/packages/pure-parse/src/guard/object.test.ts
+++ b/packages/pure-parse/src/guard/object.test.ts
@@ -2,8 +2,8 @@ import { objectGuard, objectGuardNoJit } from './object'
 import { describe, expect, it, test } from 'vitest'
 import { isNumber, isString, isUndefined } from './primitives'
 import { Guard } from './types'
-import { union } from './union'
-import { optional, undefineable } from './optional'
+import { unionGuard } from './union'
+import { optionalGuard, undefineableGuard } from './optional'
 
 const suits = [
   {
@@ -62,7 +62,7 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
             objectGuard<User1>({
               id: isNumber,
               // @ts-expect-error
-              name: optional(isString),
+              name: optionalGuard(isString),
             })
 
             type UserUndefinable = {
@@ -72,12 +72,12 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
             objectGuard<UserUndefinable>({
               id: isNumber,
               // required property, union of string and undefined
-              name: undefineable(isString),
+              name: undefineableGuard(isString),
             })
             objectGuard<UserUndefinable>({
               id: isNumber,
               // @ts-expect-error - name can be undefined, but it is not optional
-              name: optional(isString),
+              name: optionalGuard(isString),
             })
             objectGuard<UserUndefinable>({
               id: isNumber,
@@ -114,12 +114,12 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
             objectGuard<UserOptional>({
               id: isNumber,
               // @ts-expect-error - requires optional function
-              name: union(isUndefined, isString),
+              name: unionGuard(isUndefined, isString),
             })
             objectGuard<UserOptional>({
               id: isNumber,
               // As expected; requires the optional function
-              name: optional(isString),
+              name: optionalGuard(isString),
             })
           })
           it('works with complex objects', () => {
@@ -136,7 +136,7 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
             objectGuard<User1>({
               id: isNumber,
               name: isString,
-              address: optional(
+              address: optionalGuard(
                 objectGuard({
                   country: isString,
                   city: isString,
@@ -161,7 +161,7 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
               // @ts-expect-error
               id: isNumber,
               name: isString,
-              address: optional(
+              address: optionalGuard(
                 objectGuard({
                   country: isString,
                   city: isString,
@@ -223,7 +223,7 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
       })
       test('that undefinable properties are required', () => {
         const isObj = objectGuard({
-          a: undefineable(isString),
+          a: undefineableGuard(isString),
         })
         expect(
           isObj({
@@ -235,7 +235,7 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
       })
       it('validates optional properties', () => {
         const isObj = objectGuard({
-          a: optional(isString),
+          a: optionalGuard(isString),
         })
         expect(
           isObj({
@@ -247,12 +247,12 @@ suits.forEach(({ name: suiteName, fn: objectGuard }) => {
       })
       it('differentiates between undefined and missing properties', () => {
         const isOptionalObj = objectGuard({
-          a: optional(isString),
+          a: optionalGuard(isString),
         })
         expect(isOptionalObj({})).toEqual(true)
         expect(isOptionalObj({ a: undefined })).toEqual(true)
         const isUnionObj = objectGuard({
-          a: union(isString, isUndefined),
+          a: unionGuard(isString, isUndefined),
         })
         expect(isUnionObj({})).toEqual(false)
         expect(isUnionObj({ a: undefined })).toEqual(true)

--- a/packages/pure-parse/src/guard/optional.test.ts
+++ b/packages/pure-parse/src/guard/optional.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, test } from 'vitest'
-import { nullable, optional, optionalNullable, undefineable } from './optional'
+import {
+  nullableGuard,
+  optionalGuard,
+  optionalNullableGuard,
+  undefineableGuard,
+} from './optional'
 import { isBoolean, isNumber, isString } from './primitives'
 import { objectGuard } from './object'
 import { Infer } from '../common'
@@ -7,24 +12,24 @@ import { Equals } from '../internals'
 
 describe('optional', () => {
   it('matches undefined', () => {
-    expect(optional(isString)(undefined)).toEqual(true)
+    expect(optionalGuard(isString)(undefined)).toEqual(true)
   })
   it('mismatches undefined', () => {
-    expect(optional(isString)(null)).toEqual(false)
+    expect(optionalGuard(isString)(null)).toEqual(false)
   })
   it('matches the guard type of the guard argument', () => {
-    expect(optional(isBoolean)(true)).toEqual(true)
-    expect(optional(isNumber)(123)).toEqual(true)
-    expect(optional(isString)('hello')).toEqual(true)
+    expect(optionalGuard(isBoolean)(true)).toEqual(true)
+    expect(optionalGuard(isNumber)(123)).toEqual(true)
+    expect(optionalGuard(isString)('hello')).toEqual(true)
   })
   it('only matches the guard type of the guard argument', () => {
-    expect(optional(isBoolean)(123)).toEqual(false)
-    expect(optional(isNumber)('hello')).toEqual(false)
-    expect(optional(isString)(true)).toEqual(false)
+    expect(optionalGuard(isBoolean)(123)).toEqual(false)
+    expect(optionalGuard(isNumber)('hello')).toEqual(false)
+    expect(optionalGuard(isString)(true)).toEqual(false)
   })
   it('represent optional properties', () => {
     const isObj = objectGuard({
-      a: optional(isString),
+      a: optionalGuard(isString),
     })
     expect(isObj({ a: 'hello' })).toEqual(true)
     expect(isObj({ a: undefined })).toEqual(true)
@@ -33,7 +38,7 @@ describe('optional', () => {
   test('type inference', () => {
     const isObj = objectGuard({
       id: isNumber,
-      name: optional(isString),
+      name: optionalGuard(isString),
     })
     type User = {
       id: number
@@ -58,42 +63,42 @@ describe('optional', () => {
 })
 describe('nullable', () => {
   it('matches undefined', () => {
-    expect(nullable(isString)(undefined)).toEqual(false)
+    expect(nullableGuard(isString)(undefined)).toEqual(false)
   })
   it('mismatches undefined', () => {
-    expect(nullable(isString)(null)).toEqual(true)
+    expect(nullableGuard(isString)(null)).toEqual(true)
   })
   it('matches the guard type of the guard argument', () => {
-    expect(nullable(isBoolean)(true)).toEqual(true)
-    expect(nullable(isNumber)(123)).toEqual(true)
-    expect(nullable(isString)('hello')).toEqual(true)
+    expect(nullableGuard(isBoolean)(true)).toEqual(true)
+    expect(nullableGuard(isNumber)(123)).toEqual(true)
+    expect(nullableGuard(isString)('hello')).toEqual(true)
   })
   it('only matches the guard type of the guard argument', () => {
-    expect(nullable(isBoolean)(123)).toEqual(false)
-    expect(nullable(isNumber)('hello')).toEqual(false)
-    expect(nullable(isString)(true)).toEqual(false)
+    expect(nullableGuard(isBoolean)(123)).toEqual(false)
+    expect(nullableGuard(isNumber)('hello')).toEqual(false)
+    expect(nullableGuard(isString)(true)).toEqual(false)
   })
 })
 describe('optionalNullable', () => {
   it('matches undefined', () => {
-    expect(optionalNullable(isString)(undefined)).toEqual(true)
+    expect(optionalNullableGuard(isString)(undefined)).toEqual(true)
   })
   it('mismatches undefined', () => {
-    expect(optionalNullable(isString)(null)).toEqual(true)
+    expect(optionalNullableGuard(isString)(null)).toEqual(true)
   })
   it('matches the guard type of the guard argument', () => {
-    expect(optionalNullable(isBoolean)(true)).toEqual(true)
-    expect(optionalNullable(isNumber)(123)).toEqual(true)
-    expect(optionalNullable(isString)('hello')).toEqual(true)
+    expect(optionalNullableGuard(isBoolean)(true)).toEqual(true)
+    expect(optionalNullableGuard(isNumber)(123)).toEqual(true)
+    expect(optionalNullableGuard(isString)('hello')).toEqual(true)
   })
   it('only matches the guard type of the guard argument', () => {
-    expect(optionalNullable(isBoolean)(123)).toEqual(false)
-    expect(optionalNullable(isNumber)('hello')).toEqual(false)
-    expect(optionalNullable(isString)(true)).toEqual(false)
+    expect(optionalNullableGuard(isBoolean)(123)).toEqual(false)
+    expect(optionalNullableGuard(isNumber)('hello')).toEqual(false)
+    expect(optionalNullableGuard(isString)(true)).toEqual(false)
   })
   it('represent optional properties', () => {
     const isObj = objectGuard({
-      a: optionalNullable(isString),
+      a: optionalNullableGuard(isString),
     })
     expect(isObj({ a: 'hello' })).toEqual(true)
     expect(isObj({ a: undefined })).toEqual(true)
@@ -103,37 +108,37 @@ describe('optionalNullable', () => {
 })
 describe('nullable', () => {
   it('mismatches undefined', () => {
-    expect(nullable(isString)(undefined)).toEqual(false)
+    expect(nullableGuard(isString)(undefined)).toEqual(false)
   })
   it('matches null', () => {
-    expect(nullable(isString)(null)).toEqual(true)
+    expect(nullableGuard(isString)(null)).toEqual(true)
   })
   it('matches the guard type of the guard argument', () => {
-    expect(nullable(isBoolean)(true)).toEqual(true)
-    expect(nullable(isNumber)(123)).toEqual(true)
-    expect(nullable(isString)('hello')).toEqual(true)
+    expect(nullableGuard(isBoolean)(true)).toEqual(true)
+    expect(nullableGuard(isNumber)(123)).toEqual(true)
+    expect(nullableGuard(isString)('hello')).toEqual(true)
   })
   it('only matches the guard type of the guard argument', () => {
-    expect(nullable(isBoolean)(123)).toEqual(false)
-    expect(nullable(isNumber)('hello')).toEqual(false)
-    expect(nullable(isString)(true)).toEqual(false)
+    expect(nullableGuard(isBoolean)(123)).toEqual(false)
+    expect(nullableGuard(isNumber)('hello')).toEqual(false)
+    expect(nullableGuard(isString)(true)).toEqual(false)
   })
 })
 describe('undefinable', () => {
   it('matches undefined', () => {
-    expect(undefineable(isString)(undefined)).toEqual(true)
+    expect(undefineableGuard(isString)(undefined)).toEqual(true)
   })
   it('mismatches null', () => {
-    expect(undefineable(isString)(null)).toEqual(false)
+    expect(undefineableGuard(isString)(null)).toEqual(false)
   })
   it('matches the guard type of the guard argument', () => {
-    expect(undefineable(isBoolean)(true)).toEqual(true)
-    expect(undefineable(isNumber)(123)).toEqual(true)
-    expect(undefineable(isString)('hello')).toEqual(true)
+    expect(undefineableGuard(isBoolean)(true)).toEqual(true)
+    expect(undefineableGuard(isNumber)(123)).toEqual(true)
+    expect(undefineableGuard(isString)('hello')).toEqual(true)
   })
   it('only matches the guard type of the guard argument', () => {
-    expect(undefineable(isBoolean)(123)).toEqual(false)
-    expect(undefineable(isNumber)('hello')).toEqual(false)
-    expect(undefineable(isString)(true)).toEqual(false)
+    expect(undefineableGuard(isBoolean)(123)).toEqual(false)
+    expect(undefineableGuard(isNumber)('hello')).toEqual(false)
+    expect(undefineableGuard(isString)(true)).toEqual(false)
   })
 })

--- a/packages/pure-parse/src/guard/optional.ts
+++ b/packages/pure-parse/src/guard/optional.ts
@@ -1,5 +1,5 @@
 import { Guard, OptionalGuard } from './types'
-import { union } from './union'
+import { unionGuard } from './union'
 import { isNull, isUndefined } from './primitives'
 import { optionalSymbol } from '../internals'
 
@@ -7,26 +7,27 @@ import { optionalSymbol } from '../internals'
  * Represent an optional property, which is different from a required property that can be `undefined`.
  * @param guard
  */
-export const optional = <T>(guard: Guard<T>): OptionalGuard<T> =>
+export const optionalGuard = <T>(guard: Guard<T>): OptionalGuard<T> =>
   /*
    * { [optionalValue]: true } is used at runtime by `object` to check if a guard represents an optional value.
    */
-  Object.assign(union(isUndefined, guard), {
+  Object.assign(unionGuard(isUndefined, guard), {
     [optionalSymbol]: true,
   }) as OptionalGuard<T>
 /**
  * Create an optional property that also can be `null`. Convenient when creating optional nullable properties in objects. Alias for `optional(union(isNull, guard))`.
  * @param guard
  */
-export const optionalNullable = <T>(guard: Guard<T>) =>
-  optional(union(isNull, guard))
+export const optionalNullableGuard = <T>(guard: Guard<T>) =>
+  optionalGuard(unionGuard(isNull, guard))
 /**
  * Create a union with `null`. Convenient when creating nullable properties in objects. Alias for `union(isNull, guard)`.
  * @param guard
  */
-export const nullable = <T>(guard: Guard<T>) => union(isNull, guard)
+export const nullableGuard = <T>(guard: Guard<T>) => unionGuard(isNull, guard)
 /**
  * Create a union with `undefined`, which is different from optional properties. Alias for `union(isUndefined, guard)`.
  * @param guard
  */
-export const undefineable = <T>(guard: Guard<T>) => union(isUndefined, guard)
+export const undefineableGuard = <T>(guard: Guard<T>) =>
+  unionGuard(isUndefined, guard)

--- a/packages/pure-parse/src/guard/records.test.ts
+++ b/packages/pure-parse/src/guard/records.test.ts
@@ -1,79 +1,79 @@
 import { describe, expect, it, test } from 'vitest'
-import { partialRecord, record } from './records'
+import { partialRecordGuard, recordGuard } from './records'
 import { isBoolean, isNumber, isString } from './primitives'
 import { Guard } from './types'
-import { literal } from './literal'
+import { literalGuard } from './literal'
 import { objectGuard } from './object'
-import { union } from './union'
+import { unionGuard } from './union'
 import { arrayGuard } from './arrays'
-import { optional } from './optional'
+import { optionalGuard } from './optional'
 
 describe('partial records', () => {
   describe('type checking', () => {
     it('returns a guard', () => {
-      partialRecord(isString, isString) satisfies Guard<
+      partialRecordGuard(isString, isString) satisfies Guard<
         Partial<Record<string, string>>
       >
-      partialRecord(isString, isNumber) satisfies Guard<
+      partialRecordGuard(isString, isNumber) satisfies Guard<
         Partial<Record<string, number>>
       >
       // @ts-expect-error
-      partialRecord(isString, isString) satisfies Guard<
+      partialRecordGuard(isString, isString) satisfies Guard<
         Partial<Record<string, number>>
       >
     })
     describe('explicit generic type annotation', () => {
       test('string as key', () => {
-        partialRecord<string, string>(isString, isString)
-        partialRecord<string, number[]>(isString, arrayGuard(isNumber))
+        partialRecordGuard<string, string>(isString, isString)
+        partialRecordGuard<string, number[]>(isString, arrayGuard(isNumber))
         // @ts-expect-error
-        partialRecord<string, string>(isString, isNumber)
+        partialRecordGuard<string, string>(isString, isNumber)
         // @ts-expect-error
-        partialRecord<string, number[]>(isString, arrayGuard(isString))
+        partialRecordGuard<string, number[]>(isString, arrayGuard(isString))
       })
       test('literal union as key', () => {
-        partialRecord<'a', string>(literal('a'), isString)
+        partialRecordGuard<'a', string>(literalGuard('a'), isString)
         // @ts-expect-error
-        partialRecord<'a', string>(isString, isString)
+        partialRecordGuard<'a', string>(isString, isString)
         // @ts-expect-error
-        partialRecord<'a', string>(literal('b'), isString)
+        partialRecordGuard<'a', string>(literalGuard('b'), isString)
       })
     })
   })
   it('validates null', () => {
-    expect(partialRecord(isString, isString)(null)).toEqual(false)
+    expect(partialRecordGuard(isString, isString)(null)).toEqual(false)
   })
   it('validates undefined', () => {
-    expect(partialRecord(isString, isString)(undefined)).toEqual(false)
+    expect(partialRecordGuard(isString, isString)(undefined)).toEqual(false)
   })
   it('validates empty records', () => {
-    expect(partialRecord(isString, isString)({})).toEqual(true)
+    expect(partialRecordGuard(isString, isString)({})).toEqual(true)
   })
   it('invalidates empty arrays', () => {
-    expect(partialRecord(isString, isString)([])).toEqual(false)
+    expect(partialRecordGuard(isString, isString)([])).toEqual(false)
   })
   it('invalidates arrays', () => {
-    expect(partialRecord(isString, isString)(['a'])).toEqual(false)
+    expect(partialRecordGuard(isString, isString)(['a'])).toEqual(false)
   })
   it('validates records where the type of the keys match', () => {
     expect(
-      partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
+      partialRecordGuard(isString, isString)({ a: 'hello', b: 'hello2' }),
     ).toEqual(true)
-    expect(partialRecord(isString, isNumber)({ a: 1, b: 1 })).toEqual(true)
-    expect(partialRecord(isString, isBoolean)({ a: true, b: false })).toEqual(
-      true,
-    )
+    expect(partialRecordGuard(isString, isNumber)({ a: 1, b: 1 })).toEqual(true)
+    expect(
+      partialRecordGuard(isString, isBoolean)({ a: true, b: false }),
+    ).toEqual(true)
   })
   it('invalidates records where the type of any key does not match', () => {
-    expect(partialRecord(isString, isString)({ a: 'hello', b: 1 })).toEqual(
-      false,
-    )
-    expect(partialRecord(isString, isNumber)({ a: 'hello', b: 1 })).toEqual(
-      false,
-    )
-    expect(partialRecord(isString, isBoolean)({ a: 'hello', b: true })).toEqual(
-      false,
-    )
+    expect(
+      partialRecordGuard(isString, isString)({ a: 'hello', b: 1 }),
+    ).toEqual(false)
+    expect(
+      partialRecordGuard(isString, isNumber)({ a: 'hello', b: 1 }),
+    ).toEqual(false)
+    expect(
+      partialRecordGuard(isString, isBoolean)({ a: 'hello', b: true }),
+    ).toEqual(false)
   })
   test('extra properties in the schema', () => {
     const isObj = objectGuard({
@@ -85,29 +85,29 @@ describe('partial records', () => {
   describe('keys', () => {
     it('allows keys to be of type string', () => {
       expect(
-        partialRecord(isString, isString)({ a: 'hello', b: 'hello2' }),
+        partialRecordGuard(isString, isString)({ a: 'hello', b: 'hello2' }),
       ).toEqual(true)
-      expect(partialRecord(isString, isString)({})).toEqual(true)
+      expect(partialRecordGuard(isString, isString)({})).toEqual(true)
     })
     it('does not allow extra keys', () => {
-      const isKey = union(literal('a'), literal('b'))
+      const isKey = unionGuard(literalGuard('a'), literalGuard('b'))
       expect(
-        partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
+        partialRecordGuard(isKey, isString)({ a: 'hello', b: 'hello2' }),
       ).toEqual(true)
       expect(
-        partialRecord(
+        partialRecordGuard(
           isKey,
           isString,
         )({ a: 'hello', b: 'hello2', c: 'hello3' }),
       ).toEqual(false)
     })
     it('allows each key to be omitted', () => {
-      const isKey = union(literal('a'), literal('b'))
+      const isKey = unionGuard(literalGuard('a'), literalGuard('b'))
       expect(
-        partialRecord(isKey, isString)({ a: 'hello', b: 'hello2' }),
+        partialRecordGuard(isKey, isString)({ a: 'hello', b: 'hello2' }),
       ).toEqual(true)
-      expect(partialRecord(isKey, isString)({ a: 'hello' })).toEqual(true)
-      expect(partialRecord(isKey, isString)({})).toEqual(true)
+      expect(partialRecordGuard(isKey, isString)({ a: 'hello' })).toEqual(true)
+      expect(partialRecordGuard(isKey, isString)({})).toEqual(true)
     })
   })
 })
@@ -115,81 +115,93 @@ describe('records', () => {
   describe('type checking', () => {
     it('returns a guard', () => {
       const keys = ['a', 'b', 'c'] as const
-      record(keys, isString) satisfies Guard<Record<string, string>>
-      record(keys, isNumber) satisfies Guard<Record<string, number>>
+      recordGuard(keys, isString) satisfies Guard<Record<string, string>>
+      recordGuard(keys, isNumber) satisfies Guard<Record<string, number>>
       // @ts-expect-error
-      record(keys, isString) satisfies Guard<Record<string, number>>
+      recordGuard(keys, isString) satisfies Guard<Record<string, number>>
     })
     describe('explicit generic type annotation', () => {
       test('string as key', () => {})
       test('literal union as key', () => {
-        record<['a', 'b'], string>(['a', 'b'], isString)
-        record<['a', 'b'], number[]>(['a', 'b'], arrayGuard(isNumber))
+        recordGuard<['a', 'b'], string>(['a', 'b'], isString)
+        recordGuard<['a', 'b'], number[]>(['a', 'b'], arrayGuard(isNumber))
         // @ts-expect-error
-        record<['a', 'b'], string>(['a', 'b'], isNumber)
+        recordGuard<['a', 'b'], string>(['a', 'b'], isNumber)
         // @ts-expect-error
-        record<['a', 'b'], number[]>(['a', 'b'], arrayGuard(isString))
+        recordGuard<['a', 'b'], number[]>(['a', 'b'], arrayGuard(isString))
       })
     })
   })
   it('validates null', () => {
-    expect(record([], isString)(null)).toEqual(false)
+    expect(recordGuard([], isString)(null)).toEqual(false)
   })
   it('validates undefined', () => {
-    expect(record([], isString)(undefined)).toEqual(false)
+    expect(recordGuard([], isString)(undefined)).toEqual(false)
   })
   it('validates empty records', () => {
-    expect(record([], isString)({})).toEqual(true)
+    expect(recordGuard([], isString)({})).toEqual(true)
   })
   it('invalidates empty arrays', () => {
-    expect(record([], isString)([])).toEqual(false)
+    expect(recordGuard([], isString)([])).toEqual(false)
   })
   it('invalidates arrays', () => {
-    expect(record([], isString)(['a'])).toEqual(false)
+    expect(recordGuard([], isString)(['a'])).toEqual(false)
   })
   it('validates records where the type of the keys match', () => {
-    expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
+    expect(
+      recordGuard(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
+    ).toEqual(true)
+    expect(recordGuard(['a', 'b'], isNumber)({ a: 1, b: 1 })).toEqual(true)
+    expect(recordGuard(['a', 'b'], isBoolean)({ a: true, b: false })).toEqual(
       true,
     )
-    expect(record(['a', 'b'], isNumber)({ a: 1, b: 1 })).toEqual(true)
-    expect(record(['a', 'b'], isBoolean)({ a: true, b: false })).toEqual(true)
   })
   it('invalidates records where the type of any key does not match', () => {
-    expect(record(['a', 'b'], isString)({ a: 'hello', b: 1 })).toEqual(false)
-    expect(record(['a', 'b'], isNumber)({ a: 'hello', b: 1 })).toEqual(false)
-    expect(record(['a', 'b'], isBoolean)({ a: 'hello', b: true })).toEqual(
+    expect(recordGuard(['a', 'b'], isString)({ a: 'hello', b: 1 })).toEqual(
+      false,
+    )
+    expect(recordGuard(['a', 'b'], isNumber)({ a: 'hello', b: 1 })).toEqual(
+      false,
+    )
+    expect(recordGuard(['a', 'b'], isBoolean)({ a: 'hello', b: true })).toEqual(
       false,
     )
   })
   describe('keys', () => {
     it('allows keys to be of type string', () => {
-      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
-        true,
-      )
+      expect(
+        recordGuard(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
     })
     it('requires all keys to be present', () => {
-      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
-        true,
-      )
-      expect(record(['a', 'b'], isString)({ a: 'hello' })).toEqual(false)
-      expect(record(['a', 'b'], isString)({ b: 'hello2' })).toEqual(false)
+      expect(
+        recordGuard(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(recordGuard(['a', 'b'], isString)({ a: 'hello' })).toEqual(false)
+      expect(recordGuard(['a', 'b'], isString)({ b: 'hello2' })).toEqual(false)
     })
     it('does not allow extra keys', () => {
-      expect(record(['a', 'b'], isString)({ a: 'hello', b: 'hello2' })).toEqual(
-        true,
-      )
       expect(
-        record(['a', 'b'], isString)({ a: 'hello', b: 'hello2', c: 'hello3' }),
+        recordGuard(['a', 'b'], isString)({ a: 'hello', b: 'hello2' }),
+      ).toEqual(true)
+      expect(
+        recordGuard(
+          ['a', 'b'],
+          isString,
+        )({ a: 'hello', b: 'hello2', c: 'hello3' }),
       ).toEqual(false)
     })
     it('handles optional keys', () => {
       expect(
-        record(['a', 'b'], optional(isString))({ a: 'hello', b: 'hello2' }),
+        recordGuard(
+          ['a', 'b'],
+          optionalGuard(isString),
+        )({ a: 'hello', b: 'hello2' }),
       ).toEqual(true)
-      expect(record(['a', 'b'], optional(isString))({ a: 'hello' })).toEqual(
-        true,
-      )
-      expect(record(['a', 'b'], optional(isString))({})).toEqual(true)
+      expect(
+        recordGuard(['a', 'b'], optionalGuard(isString))({ a: 'hello' }),
+      ).toEqual(true)
+      expect(recordGuard(['a', 'b'], optionalGuard(isString))({})).toEqual(true)
     })
   })
 })

--- a/packages/pure-parse/src/guard/records.ts
+++ b/packages/pure-parse/src/guard/records.ts
@@ -11,7 +11,7 @@ import { Guard } from './types'
  * @param keys validates every key
  * @param valueGuard validates every value
  */
-export const record =
+export const recordGuard =
   <Keys extends readonly [...string[]], Value>(
     keys: Keys,
     valueGuard: Guard<Value>,
@@ -36,7 +36,7 @@ export const record =
  * @param keyGard validates every key
  * @param valueGuard validates every value
  */
-export const partialRecord =
+export const partialRecordGuard =
   <Key extends string, Value>(
     keyGard: Guard<Key>,
     valueGuard: Guard<Value>,

--- a/packages/pure-parse/src/guard/tuple.test.ts
+++ b/packages/pure-parse/src/guard/tuple.test.ts
@@ -1,54 +1,56 @@
 import { describe, expect, it, test } from 'vitest'
-import { tuple } from './tuple'
+import { tupleGuard } from './tuple'
 import { Guard } from './types'
 import { isBoolean, isNumber, isString } from './primitives'
 
 describe('tuples', () => {
   describe('type checking', () => {
     it('returns a guard', () => {
-      tuple([]) satisfies Guard<[]>
-      tuple([isString]) satisfies Guard<[string]>
-      tuple([isString, isNumber]) satisfies Guard<[string, number]>
-      tuple([isNumber, isNumber, isNumber]) satisfies Guard<
+      tupleGuard([]) satisfies Guard<[]>
+      tupleGuard([isString]) satisfies Guard<[string]>
+      tupleGuard([isString, isNumber]) satisfies Guard<[string, number]>
+      tupleGuard([isNumber, isNumber, isNumber]) satisfies Guard<
         [number, number, number]
       >
 
       // @ts-expect-error
-      tuple([isNumber]) satisfies Guard<[number, number]>
+      tupleGuard([isNumber]) satisfies Guard<[number, number]>
       // @ts-expect-error
-      tuple([isString, isString]) satisfies Guard<[number, number]>
+      tupleGuard([isString, isString]) satisfies Guard<[number, number]>
       // @ts-expect-error
-      tuple([isNumber, isNumber]) satisfies Guard<[string, string]>
+      tupleGuard([isNumber, isNumber]) satisfies Guard<[string, string]>
     })
     test('explicit generic type annotation', () => {
-      tuple<[]>([])
-      tuple<[string]>([isString])
-      tuple<[string, number]>([isString, isNumber])
-      tuple<[number, number, number]>([isNumber, isNumber, isNumber])
+      tupleGuard<[]>([])
+      tupleGuard<[string]>([isString])
+      tupleGuard<[string, number]>([isString, isNumber])
+      tupleGuard<[number, number, number]>([isNumber, isNumber, isNumber])
       // @ts-expect-error
-      tuple<[number, number]>([isNumber])
+      tupleGuard<[number, number]>([isNumber])
       // @ts-expect-error
-      tuple<[number, number]>([isString, isString])
+      tupleGuard<[number, number]>([isString, isString])
       // @ts-expect-error
-      tuple<[string, string]>([isNumber, isNumber])
+      tupleGuard<[string, string]>([isNumber, isNumber])
     })
   })
   it('validates each element', () => {
-    expect(tuple([])([])).toEqual(true)
-    expect(tuple([isString])(['hello'])).toEqual(true)
-    expect(tuple([isString, isNumber])(['hello', 123])).toEqual(true)
+    expect(tupleGuard([])([])).toEqual(true)
+    expect(tupleGuard([isString])(['hello'])).toEqual(true)
+    expect(tupleGuard([isString, isNumber])(['hello', 123])).toEqual(true)
     expect(
-      tuple([isString, isNumber, isBoolean])(['hello', 123, false]),
+      tupleGuard([isString, isNumber, isBoolean])(['hello', 123, false]),
     ).toEqual(true)
   })
   it('does not allow additional elements', () => {
-    expect(tuple([])([1])).toEqual(false)
-    expect(tuple([isString])(['hello', 'hello again'])).toEqual(false)
-    expect(tuple([isString, isNumber])(['hello', 123, true])).toEqual(false)
+    expect(tupleGuard([])([1])).toEqual(false)
+    expect(tupleGuard([isString])(['hello', 'hello again'])).toEqual(false)
+    expect(tupleGuard([isString, isNumber])(['hello', 123, true])).toEqual(
+      false,
+    )
   })
   it('does not allow fewer elements', () => {
-    expect(tuple([isBoolean])([])).toEqual(false)
-    expect(tuple([isString, isString])(['hello'])).toEqual(false)
-    expect(tuple([isString, isNumber])([])).toEqual(false)
+    expect(tupleGuard([isBoolean])([])).toEqual(false)
+    expect(tupleGuard([isString, isString])(['hello'])).toEqual(false)
+    expect(tupleGuard([isString, isNumber])([])).toEqual(false)
   })
 })

--- a/packages/pure-parse/src/guard/tuple.ts
+++ b/packages/pure-parse/src/guard/tuple.ts
@@ -3,7 +3,7 @@ import { Guard } from './types'
 /**
  * @param guards an array of guards. Each guard validates the corresponding element in the data tuple.
  */
-export const tuple =
+export const tupleGuard =
   <T extends readonly [...unknown[]]>(
     guards: [
       ...{

--- a/packages/pure-parse/src/guard/union.test.ts
+++ b/packages/pure-parse/src/guard/union.test.ts
@@ -1,74 +1,76 @@
 import { describe, expect, it } from 'vitest'
-import { union } from './union'
-import { literal } from './literal'
+import { unionGuard } from './union'
+import { literalGuard } from './literal'
 import { Guard } from './types'
 import { isNull, isNumber, isString, isUndefined } from './primitives'
 
 describe('unions', () => {
   describe('type checking', () => {
     it('returns a guard', () => {
-      union(literal('red'), literal('green'), literal('blue')) satisfies Guard<
-        'red' | 'green' | 'blue'
-      >
-      union(isString, isUndefined) satisfies Guard<string | undefined>
-      union(isString, isNumber) satisfies Guard<string | number>
-      union(isString) satisfies Guard<string>
+      unionGuard(
+        literalGuard('red'),
+        literalGuard('green'),
+        literalGuard('blue'),
+      ) satisfies Guard<'red' | 'green' | 'blue'>
+      unionGuard(isString, isUndefined) satisfies Guard<string | undefined>
+      unionGuard(isString, isNumber) satisfies Guard<string | number>
+      unionGuard(isString) satisfies Guard<string>
 
-      union(
-        literal('red'),
-        literal('green'),
-        literal('blue'),
+      unionGuard(
+        literalGuard('red'),
+        literalGuard('green'),
+        literalGuard('blue'),
         // @ts-expect-error
       ) satisfies Guard<'a' | 'b' | 'c'>
-      union(
-        literal('red'),
-        literal('green'),
-        literal('blue'),
+      unionGuard(
+        literalGuard('red'),
+        literalGuard('green'),
+        literalGuard('blue'),
         // @ts-expect-error
       ) satisfies Guard<'red'>
       // @ts-expect-error
-      union(isString, isUndefined) satisfies Guard<string>
+      unionGuard(isString, isUndefined) satisfies Guard<string>
     })
     describe('explicit generic type annotation', () => {
       it('works with literals', () => {
-        union<['red', 'green', 'blue']>(
-          literal('red'),
-          literal('green'),
-          literal('blue'),
+        unionGuard<['red', 'green', 'blue']>(
+          literalGuard('red'),
+          literalGuard('green'),
+          literalGuard('blue'),
         )
-        union<['red', 'green', 'blue']>(
+        unionGuard<['red', 'green', 'blue']>(
           // @ts-expect-error
-          literal('a'),
-          literal('b'),
-          literal('c'),
+          literalGuard('a'),
+          literalGuard('b'),
+          literalGuard('c'),
         )
       })
       it('requires a guard of each type', () => {
-        union<[string, undefined]>(isString, isUndefined)
+        unionGuard<[string, undefined]>(isString, isUndefined)
         // @ts-expect-error
-        union<[string, undefined]>(isUndefined)
+        unionGuard<[string, undefined]>(isUndefined)
         // @ts-expect-error
-        union<[string, undefined]>(isString)
+        unionGuard<[string, undefined]>(isString)
       })
       it('allows nested guards', () => {
-        union<[string, number, undefined | null]>(
+        unionGuard<[string, number, undefined | null]>(
           isString,
           isNumber,
-          union(isUndefined, isNull),
+          unionGuard(isUndefined, isNull),
         )
       })
       it('handles primitive types', () => {
-        union<[string, undefined]>(isString, isUndefined)
-        union<[string, number]>(isString, isNumber)
+        unionGuard<[string, undefined]>(isString, isUndefined)
+        unionGuard<[string, number]>(isString, isNumber)
         // @ts-expect-error
-        union<[string, undefined]>(union(isString))
+        unionGuard<[string, undefined]>(unionGuard(isString))
         // @ts-expect-error
-        union<string>(union(isString, isUndefined))
+        unionGuard<string>(unionGuard(isString, isUndefined))
       })
     })
   })
   it('does not match anything when the array is empty', () => {
-    const isUnion = union()
+    const isUnion = unionGuard()
     expect(isUnion('a')).toEqual(false)
     expect(isUnion(true)).toEqual(false)
     expect(isUnion(false)).toEqual(false)
@@ -76,13 +78,13 @@ describe('unions', () => {
     expect(isUnion(undefined)).toEqual(false)
   })
   it('matches any of the the guards in the array', () => {
-    const isUnion = union(isString, isNumber, isNull)
+    const isUnion = unionGuard(isString, isNumber, isNull)
     expect(isUnion('a')).toEqual(true)
     expect(isUnion(123)).toEqual(true)
     expect(isUnion(null)).toEqual(true)
   })
   it('only matches the guards in the array', () => {
-    const isUnion = union(isString, isNumber, isNull)
+    const isUnion = unionGuard(isString, isNumber, isNull)
     expect(isUnion('a')).toEqual(true)
     expect(isUnion(123)).toEqual(true)
     expect(isUnion(null)).toEqual(true)

--- a/packages/pure-parse/src/guard/union.ts
+++ b/packages/pure-parse/src/guard/union.ts
@@ -22,7 +22,7 @@ import { Guard } from './types'
  * @param guards any of these guard functions must match the data.
  * @return a guard function that validates unions
  */
-export const union =
+export const unionGuard =
   <T extends readonly [...unknown[]]>(
     ...guards: {
       [K in keyof T]: Guard<T[K]>

--- a/packages/pure-parse/src/index.ts
+++ b/packages/pure-parse/src/index.ts
@@ -1,10 +1,3 @@
 export * from './common'
 export * from './parse'
-export {
-  arrayGuard,
-  objectGuard,
-  objectGuardNoJit,
-  isString,
-  isBoolean,
-  isNumber,
-} from './guard'
+export * from './guard'

--- a/packages/pure-parse/src/parse/literal.ts
+++ b/packages/pure-parse/src/parse/literal.ts
@@ -1,7 +1,7 @@
 // TODO rename to primitive?
 import { Primitive } from '../common'
 import { failure, ParseFailure, Parser, ParseSuccess, success } from './types'
-import { literal as literal1 } from '../guard'
+import { literalGuard as literal1 } from '../guard'
 
 /**
  * Parse a primitive value .


### PR DESCRIPTION
All higher order functions that return guards get the "Guard" suffix; e.g. `arrayGuard`.