### PR TITLE
feat: lazy

### DIFF
--- a/packages/pure-parse/src/common/index.ts
+++ b/packages/pure-parse/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './Primitive'
 export * from './Infer'
 export * from './json'
+export * from './lazy'

--- a/packages/pure-parse/src/common/lazy.test.ts
+++ b/packages/pure-parse/src/common/lazy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, test, vi } from 'vitest'
+import { lazy } from './lazy'
+import { Equals } from '../internals'
+
+describe('lazy', () => {
+  it('only constructs the function once (memoization)', () => {
+    const construct = vi.fn(() => () => 42)
+    const fn = lazy(construct)
+    fn()
+    fn()
+    expect(construct).toHaveBeenCalledTimes(1)
+  })
+  it('lets you call the wrapped function normally', () => {
+    const construct = vi.fn(() => (num: number) => num ** 3)
+    const fn = lazy(construct)
+    // Evaluation check
+    expect(fn(3.14)).toBe(3.14 ** 3)
+  })
+  test('type inference', () => {
+    const fn1 = lazy(() => () => 42)
+    const t1: Equals<typeof fn1, () => number> = true
+
+    const fn2 = lazy(() => (num: number) => num.toString())
+    const t2: Equals<typeof fn2, (num: number) => string> = true
+
+    const fn3 = lazy(() => (base: number, exp: number) => base ** exp)
+    const t3: Equals<typeof fn3, (base: number, exp: number) => number> = true
+  })
+})

--- a/packages/pure-parse/src/common/lazy.ts
+++ b/packages/pure-parse/src/common/lazy.ts
@@ -1,0 +1,11 @@
+export const lazy = <T extends (...args: never[]) => unknown>(
+  constructFn: () => T,
+): T => {
+  let fn: T | undefined
+  return ((...args) => {
+    if (!fn) {
+      fn = constructFn()
+    }
+    return fn(...args)
+  }) as T
+}


### PR DESCRIPTION
For compiled parsers that are declared in module-scope, it is best to defer the construction, as compilation is very slow.