### PR TITLE
feat: remove spread argument in equals

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ jobs:
     name: Benchmark
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Set up node
         uses: actions/setup-node@v3
         with:
@@ -20,7 +20,7 @@ jobs:
       - name: Run Benchmarks
         run: npm run start --workspace=benchmark
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: my-artifact
           path: packages/benchmark/benchmark/results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ jobs:
     name: Benchmark
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/code-integration-checks.yml
+++ b/.github/workflows/code-integration-checks.yml
@@ -1,7 +1,7 @@
-name: Tests
+name: Code Integration Checks
 on: ['push']
 jobs:
-  build:
+  integration-checks:
     runs-on: ubuntu-latest
     name: Code Inspection
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6056,7 +6056,7 @@
       }
     },
     "packages/pure-parse": {
-      "version": "0.0.0-beta.6",
+      "version": "0.0.0-beta.9",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/packages/pure-parse/docs/guide/guards.md
+++ b/packages/pure-parse/docs/guide/guards.md
@@ -111,14 +111,30 @@ isOne(1) // -> true
 isOne(2) // -> false
 ```
 
-When called with multiple arguments, `equalsGuard()` validates a union:
+To validate a union of literals, use `oneOfGuard`:
 
 ```ts
-const isDirection = equalsGuard('north', 'south', 'east', 'west')
+const isDirection = oneOfGuard(
+  equals('north'),
+  equals('south'),
+  equals('east'),
+  equals('west'),
+)
 isDirection('north') // -> true
 isDirection('east') // -> true
 
-const isDigit = equalsGuard(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+const isDigit = oneOfGuard(
+  equalsGuard(0),
+  equalsGuard(1),
+  equalsGuard(2),
+  equalsGuard(3),
+  equalsGuard(4),
+  equalsGuard(5),
+  equalsGuard(6),
+  equalsGuard(7),
+  equalsGuard(8),
+  equalsGuard(9),
+)
 isDigit(5) // -> true
 isDigit(100) // -> false
 ```
@@ -217,7 +233,12 @@ const isUser = objectGuard<User>({
 Arrays are ordered sets of elements of the same type. Use the `arrayGuard()` function to create a validation function for an arrays type:
 
 ```ts
-const isBase = equalsGuard('A', 'T', 'C', 'G')
+const isBase = oneOf(
+  equalsGuard('A'),
+  equalsGuard('T'),
+  equalsGuard('C'),
+  equalsGuard('G'),
+)
 const isDna = arrayGuard(isBase)
 isDna(['A', 'T', 'A', 'T', 'C', 'G']) // -> true
 ```

--- a/packages/pure-parse/docs/guide/parsers.md
+++ b/packages/pure-parse/docs/guide/parsers.md
@@ -115,14 +115,30 @@ parseOne(1) // -> ParseSuccess<1>
 parseOne(2) // -> ParseError
 ```
 
-When called with multiple arguments, `equals()` validates a union:
+To validate a union of literals, use `oneOf`:
 
 ```ts
-const parseDirection = equals('north', 'south', 'east', 'west')
+const parseDirection = oneOf(
+  equals('north'),
+  equals('south'),
+  equals('east'),
+  equals('west'),
+)
 parseDirection('north') // -> ParseSuccess<'north' | 'south' | 'east' | 'west'>
 parseDirection('up') // -> ParseError
 
-const parseDigit = equals(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+const parseDigit = oneOf(
+  equals(0),
+  equals(1),
+  equals(2),
+  equals(3),
+  equals(4),
+  equals(5),
+  equals(6),
+  equals(7),
+  equals(8),
+  equals(9),
+)
 parseDigit(5) // -> ParseSuccess<0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>
 parseDigit(50) // -> ParseError
 ```
@@ -223,7 +239,7 @@ const parseUser = object<User>({
 Arrays are ordered set of elements of the same type. Use the `arrays()` function to create a validation function for an arrays type:
 
 ```ts
-const parseBase = equals('A', 'T', 'C', 'G')
+const parseBase = oneOf(equals('A'), equals('T'), equals('C'), equals('G'))
 const parseDna = arrays(parseBase)
 parseDna(['A', 'T', 'A', 'T', 'C', 'G']) // -> ParseSuccess
 ```

--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-parse",
-  "version": "0.0.0-beta.7",
+  "version": "0.0.0-beta.8",
   "private": false,
   "description": "Strongly typed validation library that decouples type aliases from validation logic",
   "author": {

--- a/packages/pure-parse/package.json
+++ b/packages/pure-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pure-parse",
-  "version": "0.0.0-beta.8",
+  "version": "0.0.0-beta.9",
   "private": false,
   "description": "Strongly typed validation library that decouples type aliases from validation logic",
   "author": {

--- a/packages/pure-parse/src/guards/equals.test.ts
+++ b/packages/pure-parse/src/guards/equals.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from 'vitest'
 import { equalsGuard } from './equals'
 import { Guard } from './types'
+import { isString } from './primitives'
 
 describe('equals', () => {
   describe('type checking', () => {
@@ -23,50 +24,22 @@ describe('equals', () => {
       })
     })
     describe('explicit generic type annotation', () => {
-      it('works with literals', () => {
-        equalsGuard<['red']>('red')
+      it('works with primitives', () => {
+        equalsGuard<'red'>('red')
         // @ts-expect-error
-        equalsGuard<['green']>('red')
+        equalsGuard<'green'>('red')
 
-        equalsGuard<[1]>(1)
+        equalsGuard<1>(1)
         // @ts-expect-error
-        equalsGuard<[1]>(2)
+        equalsGuard<1>(2)
 
         // @ts-expect-error
-        equalsGuard<['1']>(1)
+        equalsGuard<'1'>(1)
       })
-    })
-  })
-  describe('unions of literals', () => {
-    it('validates unions of literals correctly', () => {
-      const isColor = equalsGuard('red', 'green', 'blue')
-      expect(isColor('red')).toEqual(true)
-      expect(isColor('green')).toEqual(true)
-      expect(isColor('blue')).toEqual(true)
-      expect(isColor('music')).toEqual(false)
-
-      const isInUnion = equalsGuard('red', 1, true)
-      expect(isInUnion('red')).toEqual(true)
-      expect(isInUnion('green')).toEqual(false)
-      expect(isInUnion(1)).toEqual(true)
-      expect(isInUnion(2)).toEqual(false)
-      expect(isInUnion(true)).toEqual(true)
-      expect(isInUnion(false)).toEqual(false)
-    })
-    it('infers the types of unions of literals', () => {
-      equalsGuard('red', 1, true) satisfies Guard<'red' | 1 | true>
-      equalsGuard('red', 'green', 'blue') satisfies Guard<
-        'red' | 'green' | 'blue'
-      >
-      // @ts-expect-error
-      equalsGuard('red', 'green', 'blue') satisfies Guard<'red'>
-    })
-    test('explicit type annotation', () => {
-      equalsGuard<['red', 'green', 'blue']>('red', 'green', 'blue')
-      // @ts-expect-error
-      equalsGuard<['red', 'green', 'blue']>('red')
-      // @ts-expect-error
-      equalsGuard<['red', 'green', 'blue']>('red', 'green', 'blue', 'music')
+      it('does not work with reference types', () => {
+        // @ts-expect-error
+        equalsGuard<{ a: 'b' }>({ a: equalsGuard('b') })
+      })
     })
   })
   describe('primitive arguments', () => {

--- a/packages/pure-parse/src/guards/equals.ts
+++ b/packages/pure-parse/src/guards/equals.ts
@@ -4,8 +4,6 @@ import { Guard } from './types'
 /**
  * Compares the input against a list of primitive values with the strict equality operator (`===`).
  * The inferred type of the guard is that of a literal type; for example, `equalsGuard('red')` returns a `Guard<'red'>`.
- * When called with multiple arguments, the guard will return `true` if the input equals to any of the provided values,
- * and thus return a union type.
  * @example
  * ```ts
  * const isRed = equalsGuard('red')
@@ -28,21 +26,9 @@ import { Guard } from './types'
  *   }),
  * ])
  * ```
- * @example
- * If you pass in multiple values, the guard will validate a union type:
- * ```ts
- * const isLogLevel = equalsGuard('debug', 'info', 'warning', 'error')
- * ```
- * @example
- * When explicitly annotating unions, provide a tuple of the union members as type argument:
- * ```ts
- * const isColor = equalsGuard<['red', 'green', 'blue']>('red', 'green', 'blue')
- * ```
- * @param constants compared against `data` with the `===` operator.
+ * @param constant compared against `data` with the `===` operator.
  */
 export const equalsGuard =
-  <const T extends readonly [...Primitive[]]>(
-    ...constants: T
-  ): Guard<T[number]> =>
-  (data: unknown): data is T[number] =>
-    constants.some((constant) => constant === data)
+  <const T extends Primitive>(constant: T): Guard<T> =>
+  (data: unknown): data is T =>
+    constant === data

--- a/packages/pure-parse/src/parsers/dictionary.test.ts
+++ b/packages/pure-parse/src/parsers/dictionary.test.ts
@@ -11,6 +11,7 @@ import { Equals } from '../internals'
 import { Infer } from '../common'
 import { failure, Parser, success } from './types'
 import { isString } from '../guards'
+import { oneOf } from './oneOf'
 
 const parseCapitalized: Parser<string> = (data) => {
   if (!isString(data)) {
@@ -37,7 +38,7 @@ describe('record', () => {
         > = true
       })
       it('infers the keys as string literal', () => {
-        const parse = dictionary(equals('a', 'b'), parseString)
+        const parse = dictionary(oneOf(equals('a'), equals('b')), parseString)
         const t0: Equals<
           Infer<typeof parse>,
           Partial<Record<'a' | 'b', string>>
@@ -50,7 +51,10 @@ describe('record', () => {
         dictionary<string, string>(parseString, parseString)
       })
       it('allows for union keys', () => {
-        dictionary<'a' | 'b', string>(equals('a', 'b'), parseString)
+        dictionary<'a' | 'b', string>(
+          oneOf(equals('a'), equals('b')),
+          parseString,
+        )
       })
       it('binds the second type argument to the second parser', () => {
         dictionary<string, string>(parseString, parseString)
@@ -103,7 +107,7 @@ describe('record', () => {
         const t0: { a: boolean; b: boolean } = { a: true, b: true }
         expect(
           dictionary(
-            equals('a', 'b'),
+            oneOf(equals('a'), equals('b')),
             parseBoolean,
           )({
             a: true,
@@ -122,7 +126,7 @@ describe('record', () => {
       it('fails on extra keys', () => {
         expect(
           dictionary(
-            equals('a', 'b'),
+            oneOf(equals('a'), equals('b')),
             parseBoolean,
           )({
             a: true,
@@ -135,7 +139,7 @@ describe('record', () => {
       test('that keys are optional', () => {
         expect(
           dictionary(
-            equals('a', 'b'),
+            oneOf(equals('a'), equals('b')),
             parseBoolean,
           )({
             a: true,

--- a/packages/pure-parse/src/parsers/equals.test.ts
+++ b/packages/pure-parse/src/parsers/equals.test.ts
@@ -206,8 +206,10 @@ describe('equals', () => {
   })
 
   describe('type inference', () => {
-    const parser0 = equals('a')
-    const t0: Equals<typeof parser0, Parser<'a'>> = true
+    it('infers the type', () => {
+      const parser0 = equals('a')
+      const t0: Equals<typeof parser0, Parser<'a'>> = true
+    })
   })
 
   describe('explicit type annotation', () => {

--- a/packages/pure-parse/src/parsers/equals.test.ts
+++ b/packages/pure-parse/src/parsers/equals.test.ts
@@ -3,6 +3,7 @@ import { equals } from './equals'
 import { withDefault } from './withDefault'
 import { Parser } from './types'
 import { Equals } from '../internals'
+import { parseString } from './primitives'
 
 const expectFailure = () => expect.objectContaining({ tag: 'failure' })
 
@@ -204,36 +205,27 @@ describe('equals', () => {
     })
   })
 
-  describe('multiple arguments', () => {
-    it('validates any of the values', () => {
-      const parser = equals('a', 'b')
-      expect(parser('a')).toEqual(
-        expect.objectContaining({
-          tag: 'success',
-          value: 'a',
-        }),
-      )
-      expect(parser('b')).toEqual(
-        expect.objectContaining({
-          tag: 'success',
-          value: 'b',
-        }),
-      )
-    })
+  describe('type inference', () => {
+    const parser0 = equals('a')
+    const t0: Equals<typeof parser0, Parser<'a'>> = true
   })
 
-  describe('type inference', () => {
-    it('infers with one argument', () => {
-      const parser0 = equals('a')
-      const t0: Equals<typeof parser0, Parser<'a'>> = true
+  describe('explicit type annotation', () => {
+    it('works with primitives', () => {
+      equals<'a'>('a')
+      // @ts-expect-error
+      equals<'a'>('b')
+
+      equals<1>(1)
+      // @ts-expect-error
+      equals<1>(2)
+
+      // @ts-expect-error
+      equals<'1'>(1)
     })
-    it('infers with multiple arguments', () => {
-      const parser0 = equals('a', 'b')
-      const t0: Equals<typeof parser0, Parser<'a' | 'b'>> = true
-    })
-    it('infers with multiple arguments of different types', () => {
-      const parser0 = equals('a', 1, false)
-      const t0: Equals<typeof parser0, Parser<'a' | 1 | false>> = true
+    it('does not work with reference types', () => {
+      // @ts-expect-error
+      equals<{ a: 'b' }>({ a: equals('b') })
     })
   })
 

--- a/packages/pure-parse/src/parsers/equals.ts
+++ b/packages/pure-parse/src/parsers/equals.ts
@@ -4,10 +4,8 @@ import { equalsGuard } from '../guards'
 import { stringify } from '../internals'
 
 /**
- * Compares the input against a list of primitive values with the strict equality operator (`===`).
+ * Compares the input against a primitive values with the strict equality operator (`===`).
  * The inferred type of the parser is that of a literal type; for example, `equals('red')` returns a `Parser<'red'>`.
- * When called with multiple arguments, the parser will succeed if the input equals to any of the provided values,
- * and thus return a union type.
  * @example
  * ```ts
  * const parseInfo = equals('info')
@@ -30,33 +28,12 @@ import { stringify } from '../internals'
  *   }),
  * ])
  * ```
- * @example
- * If you pass in multiple values, the parser will validate a union type:
- *  ```ts
- * const parseLogLevel = equals('debug', 'info', 'warning', 'error')
- * parseLogLevel('info') // => ParseSuccess<'debug' | 'info' | 'warning' | 'error'>
- * parseLogLevel('error') // => ParseSuccess<'debug' | 'info' | 'warning' | 'error'>
- * ```
- * @example
- * When explicitly annotating unions, provide a tuple of the union members as type argument:
- *  ```ts
- * const parseLogLevel = equals<['debug', 'info', 'warning', 'error']>('debug', 'info', 'warning', 'error')
- * ```
- * If you want a type alias, do it as such:
- *  ```ts
- *  type LogLevelArray = ['debug', 'info', 'warning', 'error']
- *  type LogLevel = LogLevelArray[number]
- * const parseLogLevel = equals<LogLevelArray>('debug', 'info', 'warning', 'error')
- * ```
- * @param constants One or more primitive values that are compared against `data` with the `===` operator.
+ * @param constant One or more primitive values that are compared against `data` with the `===` operator.
  * @returns A parser function that validates the input against the provided constants.
  */
-export const equals = <const T extends [...Primitive[]]>(
-  ...constants: T
-): Parser<T[number]> => {
-  const v = equalsGuard(...constants)
-  return (data: unknown): ParseSuccess<T[number]> | ParseFailure =>
-    v(data)
-      ? success(data as T[number])
-      : failure(`Does not equal to any value in ${stringify(constants)}`)
-}
+export const equals =
+  <const T extends Primitive>(constant: T): Parser<T> =>
+  (data: unknown): ParseSuccess<T> | ParseFailure =>
+    data === constant
+      ? success(data as T)
+      : failure(`Does not equal to the value in ${stringify(constant)}`)


### PR DESCRIPTION
Resolves #104

`equals` accepted rest parameters:

```
equals('red', 'green', 'blue')
```

Now it does not:


```
oneOf(
  equals('red'),
  equals('green'),
  equals('blue'),
)
```

It's more repetitive, but `equals` is mostly meant to be used for discriminated unions. Having exactly one argument would add simplicity and constitency.