### PR TITLE
feat!: restructure error handling to include message and path in ParseFailure

### DIFF
--- a/packages/pure-parse/src/parsers/ParseResult.test.ts
+++ b/packages/pure-parse/src/parsers/ParseResult.test.ts
@@ -55,14 +55,18 @@ describe('ParseResult', () => {
           propagateFailure(failure(errorMsg), { tag: 'object', key: 'a' }),
         ).toEqual(
           expect.objectContaining({
-            error: errorMsg,
+            error: expect.objectContaining({
+              message: errorMsg,
+            }),
           }),
         )
       })
       it('includes the path segment in an error with no path segments', () => {
         expect(propagateFailure(failure('errorMsg'), segmentA)).toEqual(
           expect.objectContaining({
-            path: [segmentA],
+            error: expect.objectContaining({
+              path: [segmentA],
+            }),
           }),
         )
       })
@@ -74,7 +78,9 @@ describe('ParseResult', () => {
           ),
         ).toEqual(
           expect.objectContaining({
-            path: [segmentA, segmentB],
+            error: expect.objectContaining({
+              path: [segmentA, segmentB],
+            }),
           }),
         )
         expect(
@@ -87,7 +93,9 @@ describe('ParseResult', () => {
           ),
         ).toEqual(
           expect.objectContaining({
-            path: [segmentA, segmentB, segmentC],
+            error: expect.objectContaining({
+              path: [segmentA, segmentB, segmentC],
+            }),
           }),
         )
       })

--- a/packages/pure-parse/src/parsers/ParseResult.ts
+++ b/packages/pure-parse/src/parsers/ParseResult.ts
@@ -19,8 +19,10 @@ export type ParseSuccess<T> = {
  */
 export type ParseFailure = {
   tag: 'failure'
-  error: string
-  path: PathSegment[]
+  error: {
+    message: string
+    path: PathSegment[]
+  }
 }
 
 /**
@@ -43,10 +45,12 @@ export const success = <T>(value: T): ParseSuccess<T> => ({
   value,
 })
 
-export const failure = (error: string): ParseFailure => ({
+export const failure = (message: string): ParseFailure => ({
   tag: 'failure',
-  error,
-  path: [],
+  error: {
+    message,
+    path: [],
+  },
 })
 
 /**
@@ -81,6 +85,8 @@ export const propagateFailure = (
   pathSegment: PathSegment,
 ): ParseFailure => ({
   tag: 'failure',
-  error: failureRes.error,
-  path: [pathSegment, ...failureRes.path],
+  error: {
+    message: failureRes.error.message,
+    path: [pathSegment, ...failureRes.error.path],
+  },
 })

--- a/packages/pure-parse/src/parsers/Parser.test.ts
+++ b/packages/pure-parse/src/parsers/Parser.test.ts
@@ -194,8 +194,10 @@ describe('parsing', () => {
         expect(parseNum('a')).toEqual(expectFailure())
         expect(parseNum('a')).toEqual({
           tag: 'failure',
-          error: 'Error',
-          path: [],
+          error: expect.objectContaining({
+            message: 'Error',
+            path: [],
+          }),
         })
       })
       it('can change the error message', () => {
@@ -206,7 +208,7 @@ describe('parsing', () => {
         if (isSuccess(result)) {
           throw new Error('Expected failure')
         }
-        expect(result.error).toEqual('A UUID must be a string')
+        expect(result.error.message).toEqual('A UUID must be a string')
       })
       it('can recover to a different type with type annotation', () => {
         const parseNum = recover<number | undefined>(parseNumber, () =>
@@ -218,7 +220,7 @@ describe('parsing', () => {
       it('can read the error message', () => {
         const parseFailure = () => failure('Expected type number')
         const parseNum = recover(parseFailure, (result) =>
-          failure(`${result.error}!`),
+          failure(`${result.error.message}!`),
         )
         expect(parseNum('abc')).toEqual(failure('Expected type number!'))
       })

--- a/packages/pure-parse/src/parsers/arrays.test.ts
+++ b/packages/pure-parse/src/parsers/arrays.test.ts
@@ -46,7 +46,9 @@ describe('arrays', () => {
       expect(parse(1)).toEqual(
         expect.objectContaining({
           tag: 'failure',
-          path: [],
+          error: expect.objectContaining({
+            path: [],
+          }),
         }),
       )
     })
@@ -56,7 +58,9 @@ describe('arrays', () => {
         expect(parse([1])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 0 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 0 }],
+            }),
           }),
         )
       })
@@ -65,28 +69,34 @@ describe('arrays', () => {
         expect(parse([[1]])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 0 },
-              { tag: 'array', index: 0 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 0 },
+                { tag: 'array', index: 0 },
+              ],
+            }),
           }),
         )
         expect(parse([[], [], [1]])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 2 },
-              { tag: 'array', index: 0 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 2 },
+                { tag: 'array', index: 0 },
+              ],
+            }),
           }),
         )
         expect(parse([[], ['a'], ['a', 'b', 'c', 3], []])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 2 },
-              { tag: 'array', index: 3 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 2 },
+                { tag: 'array', index: 3 },
+              ],
+            }),
           }),
         )
       })
@@ -95,19 +105,25 @@ describe('arrays', () => {
         expect(parse([1, 2, 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 0 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 0 }],
+            }),
           }),
         )
         expect(parse(['1', 2, 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 1 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 1 }],
+            }),
           }),
         )
         expect(parse(['1', '2', 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 2 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 2 }],
+            }),
           }),
         )
       })

--- a/packages/pure-parse/src/parsers/dictionary.test.ts
+++ b/packages/pure-parse/src/parsers/dictionary.test.ts
@@ -224,7 +224,12 @@ describe('record', () => {
   describe('error handling', () => {
     test('that the error points to the object when it is not an object', () => {
       expect(dictionary(parseString, parseBoolean)(1)).toEqual(
-        expect.objectContaining({ tag: 'failure', path: [] }),
+        expect.objectContaining({
+          tag: 'failure',
+          error: expect.objectContaining({
+            path: [],
+          }),
+        }),
       )
     })
     describe('property errors', () => {
@@ -240,12 +245,14 @@ describe('record', () => {
           ).toEqual(
             expect.objectContaining({
               tag: 'failure',
-              path: [
-                {
-                  tag: 'object',
-                  key: 'a',
-                },
-              ],
+              error: expect.objectContaining({
+                path: [
+                  {
+                    tag: 'object',
+                    key: 'a',
+                  },
+                ],
+              }),
             }),
           )
         })
@@ -261,12 +268,14 @@ describe('record', () => {
         ).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              {
-                tag: 'object',
-                key: 'a',
-              },
-            ],
+            error: expect.objectContaining({
+              path: [
+                {
+                  tag: 'object',
+                  key: 'a',
+                },
+              ],
+            }),
           }),
         )
       })

--- a/packages/pure-parse/src/parsers/formatting.test.ts
+++ b/packages/pure-parse/src/parsers/formatting.test.ts
@@ -53,21 +53,23 @@ describe('formatting', () => {
         expect(
           formatResult({
             tag: 'failure',
-            error: 'Expected string',
-            path: [
-              {
-                tag: 'object',
-                key: 'users',
-              },
-              {
-                tag: 'array',
-                index: 2,
-              },
-              {
-                tag: 'object',
-                key: 'name',
-              },
-            ],
+            error: {
+              message: 'Expected string',
+              path: [
+                {
+                  tag: 'object',
+                  key: 'users',
+                },
+                {
+                  tag: 'array',
+                  index: 2,
+                },
+                {
+                  tag: 'object',
+                  key: 'name',
+                },
+              ],
+            },
           }),
         ).toEqual('ParseFailure: Expected string at $.users[2].name')
       })
@@ -75,8 +77,10 @@ describe('formatting', () => {
         expect(
           formatResult({
             tag: 'failure',
-            error: 'Expected type string',
-            path: [],
+            error: {
+              message: 'Expected type string',
+              path: [],
+            },
           }),
         ).toEqual('ParseFailure: Expected type string')
       })

--- a/packages/pure-parse/src/parsers/formatting.ts
+++ b/packages/pure-parse/src/parsers/formatting.ts
@@ -43,9 +43,9 @@ export const formatResult = <T>(
 }
 
 const formatFailure = (failure: ParseFailure): string =>
-  failure.path.length === 0
-    ? failure.error
-    : `${failure.error} at ${formatPath(failure.path)}`
+  failure.error.path.length === 0
+    ? failure.error.message
+    : `${failure.error.message} at ${formatPath(failure.error.path)}`
 
 /**
  * Formats a failure `Path` to a JsonPath.

--- a/packages/pure-parse/src/parsers/object.test.ts
+++ b/packages/pure-parse/src/parsers/object.test.ts
@@ -710,7 +710,9 @@ describe('object', () => {
             expect(parse('nonanobj')).toEqual(
               expect.objectContaining({
                 tag: 'failure',
-                path: [],
+                error: expect.objectContaining({
+                  path: [],
+                }),
               }),
             )
           })
@@ -721,12 +723,14 @@ describe('object', () => {
             expect(parse({})).toEqual(
               expect.objectContaining({
                 tag: 'failure',
-                path: [
-                  {
-                    tag: 'object',
-                    key: 'a',
-                  },
-                ],
+                error: expect.objectContaining({
+                  path: [
+                    {
+                      tag: 'object',
+                      key: 'a',
+                    },
+                  ],
+                }),
               }),
             )
           })
@@ -738,12 +742,14 @@ describe('object', () => {
               expect(parse({ a: 1 })).toEqual(
                 expect.objectContaining({
                   tag: 'failure',
-                  path: [
-                    {
-                      tag: 'object',
-                      key: 'a',
-                    },
-                  ],
+                  error: expect.objectContaining({
+                    path: [
+                      {
+                        tag: 'object',
+                        key: 'a',
+                      },
+                    ],
+                  }),
                 }),
               )
             })
@@ -756,16 +762,18 @@ describe('object', () => {
               expect(parse({ a: { b: 1 } })).toEqual(
                 expect.objectContaining({
                   tag: 'failure',
-                  path: [
-                    {
-                      tag: 'object',
-                      key: 'a',
-                    },
-                    {
-                      tag: 'object',
-                      key: 'b',
-                    },
-                  ],
+                  error: expect.objectContaining({
+                    path: [
+                      {
+                        tag: 'object',
+                        key: 'a',
+                      },
+                      {
+                        tag: 'object',
+                        key: 'b',
+                      },
+                    ],
+                  }),
                 }),
               )
             })

--- a/packages/pure-parse/src/parsers/object.ts
+++ b/packages/pure-parse/src/parsers/object.ts
@@ -128,9 +128,9 @@ export const objectCompiled = <T extends Record<string, unknown>>(schema: {
   const schemaEntries = Object.entries(schema)
   const parsers = schemaEntries.map(([_, parser]) => parser)
   const statements = [
-    `if(typeof data !== 'object' || data === null) return {tag:'failure', error: ${JSON.stringify(
+    `if(typeof data !== 'object' || data === null) return {tag:'failure', error: { message: ${JSON.stringify(
       notAnObjectMsg,
-    )}, path: []}`,
+    )}, path: [] }}`,
     `const dataOutput = {}`,
     `let parseResult`,
     ...schemaEntries.map(([unescapedKey, parserFunction], i) => {
@@ -150,7 +150,7 @@ export const objectCompiled = <T extends Record<string, unknown>>(schema: {
           } 
         } else {
           parseResult = ${parser}(${value})
-          if(parseResult.tag === 'failure') return {tag:'failure', error: parseResult.error, path:[{tag:'object', key:${key}}, ...parseResult.path]}
+          if(parseResult.tag === 'failure') return {tag: 'failure', error: { message: parseResult.error.message, path:[{tag:'object', key:${key}}, ...parseResult.error.path] }}
           dataOutput[${key}] = parseResult.value
         }`
     }),

--- a/packages/pure-parse/src/parsers/tuples.test.ts
+++ b/packages/pure-parse/src/parsers/tuples.test.ts
@@ -119,7 +119,9 @@ describe('tuples', () => {
       expect(parse(1)).toEqual(
         expect.objectContaining({
           tag: 'failure',
-          path: [],
+          error: expect.objectContaining({
+            path: [],
+          }),
         }),
       )
     })
@@ -129,7 +131,9 @@ describe('tuples', () => {
         expect(parse([1])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 0 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 0 }],
+            }),
           }),
         )
       })
@@ -146,10 +150,12 @@ describe('tuples', () => {
         ).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 0 },
-              { tag: 'array', index: 0 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 0 },
+                { tag: 'array', index: 0 },
+              ],
+            }),
           }),
         )
         expect(
@@ -160,10 +166,12 @@ describe('tuples', () => {
         ).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 0 },
-              { tag: 'array', index: 1 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 0 },
+                { tag: 'array', index: 1 },
+              ],
+            }),
           }),
         )
         expect(
@@ -174,10 +182,12 @@ describe('tuples', () => {
         ).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [
-              { tag: 'array', index: 1 },
-              { tag: 'array', index: 1 },
-            ],
+            error: expect.objectContaining({
+              path: [
+                { tag: 'array', index: 1 },
+                { tag: 'array', index: 1 },
+              ],
+            }),
           }),
         )
       })
@@ -186,19 +196,25 @@ describe('tuples', () => {
         expect(parse([1, 2, 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 0 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 0 }],
+            }),
           }),
         )
         expect(parse(['1', 2, 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 1 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 1 }],
+            }),
           }),
         )
         expect(parse(['1', '2', 3])).toEqual(
           expect.objectContaining({
             tag: 'failure',
-            path: [{ tag: 'array', index: 2 }],
+            error: expect.objectContaining({
+              path: [{ tag: 'array', index: 2 }],
+            }),
           }),
         )
       })


### PR DESCRIPTION
From

```ts
export type ParseFailure = {
  tag: 'failure'
  error: string
  path: PathSegment[]
}
```

```ts
export type ParseFailure = {
  tag: 'failure'
  error: {
    message: string
    path: PathSegment[]
  }
}
```

This mean that in "left-right"/"success-failure" mapping, we can pass just the error payload. For example, in `recover`.