### PR TITLE
feat: discriminate based on ParseResult.error

### DIFF
--- a/packages/pure-parse/docs/guide/customizing.md
+++ b/packages/pure-parse/docs/guide/customizing.md
@@ -18,11 +18,10 @@ import {
   isString,
   parseNumber,
 } from 'pure-parse'
-import { isSuccess } from 'pure-parse/src'
 
 const parseStringifiedNumber: Parser<number> = (data: unknown) => {
   const result = parseNumber(data)
-  if (!isSuccess(data)) {
+  if (data.error) {
     return result
   }
   return success(result.value.toString())

--- a/packages/pure-parse/docs/guide/parsers.md
+++ b/packages/pure-parse/docs/guide/parsers.md
@@ -10,30 +10,35 @@ where `ParseResult` is a discriminated union:
 
 ```ts
 type ParseResult<T> =
-  | { tag: 'success'; value: T }
+  | { tag: 'success'; value: T; error?: never }
   | { tag: 'failure'; error: string }
 ```
 
-To find out whether the parsing was successful, read the `tag` property of the result; for example:
+To find out whether the parsing was successful, read the `error` or `tag` properties of the result; for example:
+
+...using the `error` property:
 
 ```ts
-import { parseString, parseNumber, object } from 'pure-parse'
-import data from 'my-data.json'
-import { formatResult } from 'pure-parse/src'
+const result = parseUser(data)
 
-const parseUser = object({
-  name: parseString,
-  age: parseNumber,
-})
+if (result.error) {
+  console.log(formatResult(result))
+  return
+}
+console.log(`The user's name is "${result.value.name}"`)
+```
 
+...or using the `tag` property:
+
+```ts
 const result = parseUser(data)
 
 switch (result.tag) {
-  case 'success':
-    console.log(`The user's name is "${result.value.name}"`)
-    break
   case 'failure':
     console.log(formatResult(result))
+    break
+  case 'success':
+    console.log(`The user's name is "${result.value.name}"`)
     break
 }
 ```

--- a/packages/pure-parse/docs/guide/transformations.md
+++ b/packages/pure-parse/docs/guide/transformations.md
@@ -75,7 +75,7 @@ parseNumber('abc') // -> ParseSuccess<0>
 It also allows you to customize the error message:
 
 ```ts
-import { recoverm, failure, formatResult } from 'pure-parse/src'
+import { recoverm, failure, formatResult } from 'pure-parse'
 
 const parseUuid = recover(parseString, () => failure('A UUID must be a string'))
 

--- a/packages/pure-parse/src/parsers/ParseResult.test.ts
+++ b/packages/pure-parse/src/parsers/ParseResult.test.ts
@@ -10,8 +10,27 @@ import {
   propagateFailure,
 } from './ParseResult'
 import { Equals } from '../internals'
+import { parseNumber } from './primitives'
 
 describe('ParseResult', () => {
+  describe('the `.error` property', () => {
+    it('can be used to discriminate between Success and Failure', () => {
+      const resultOk = parseNumber(123)
+      // Type checking here
+      if (resultOk.error) {
+        throw new Error('Expected success result')
+      }
+      const t1: Equals<typeof resultOk, ParseSuccess<number>> = true
+      expect(resultOk.tag).toEqual('success')
+
+      const resultError = parseNumber('abc')
+      if (!resultError.error) {
+        throw new Error('Expected failure result')
+      }
+      const t2: Equals<typeof resultError, ParseFailure> = true
+      expect(resultError.tag).toEqual('failure')
+    })
+  })
   describe('utilities', () => {
     describe('isSuccess', () => {
       test('success result', () => {
@@ -42,6 +61,30 @@ describe('ParseResult', () => {
         test('the return type is just ParseFailure', () => {
           const res = failure('Error')
           const a: Equals<typeof res, ParseFailure> = true
+        })
+      })
+    })
+    describe('success', () => {
+      it('creates a success result', () => {
+        const result = success(123)
+        expect(result).toEqual({
+          tag: 'success',
+          value: 123,
+        })
+      })
+      test('that .error not `undefined`', () => {
+        expect('error' in success(123)).toBe(false)
+      })
+    })
+    describe('failure', () => {
+      it('creates a failure result', () => {
+        const result = failure('Error message')
+        expect(result).toEqual({
+          tag: 'failure',
+          error: {
+            message: 'Error message',
+            path: [],
+          },
         })
       })
     })
@@ -98,15 +141,6 @@ describe('ParseResult', () => {
             }),
           }),
         )
-      })
-    })
-  })
-  describe('success', () => {
-    it('creates a success result', () => {
-      const result = success(123)
-      expect(result).toEqual({
-        tag: 'success',
-        value: 123,
       })
     })
   })

--- a/packages/pure-parse/src/parsers/ParseResult.ts
+++ b/packages/pure-parse/src/parsers/ParseResult.ts
@@ -10,6 +10,7 @@ import { Parser } from './Parser'
 export type ParseSuccess<T> = {
   tag: 'success'
   value: T
+  error?: never
 }
 
 /**
@@ -38,13 +39,69 @@ export type PathSegment =
       index: number
     }
 
+/**
+ * Describes the result of a parsing operation.
+ * The `tag` and `error` properties can be used to distinguish between success and failure.
+ * @example
+ * Use `error` to distinguish between success and failure:
+ * ```ts
+ * const result = parseNumber(data)
+ * if(result.error) {
+ *   console.error(formatResult(result))
+ *   return
+ * }
+ * console.log(result.value)
+ * ```
+ * @example
+ * Use `tag` to distinguish between success and failure:
+ * ```ts
+ * const result = parseNumber(data)
+ * switch (result.tag) {
+ *   case 'failure':
+ *    console.error(formatResult(result))
+ *    break
+ *   case 'success':
+ *    console.log(result.value)
+ *    break
+ */
 export type ParseResult<T> = ParseSuccess<T> | ParseFailure
 
+/**
+ * *****************************
+ * Utilities
+ * *****************************
+ */
+
+/**
+ * Create a successful parsing result.
+ * @example
+ * ```ts
+ * const customParser: Parser<number> = (data) => {
+ *   if (typeof data === 'number') {
+ *    return success(data)
+ *   }
+ *   return failure('Expected a number')
+ * }
+ * @param value
+ */
 export const success = <T>(value: T): ParseSuccess<T> => ({
   tag: 'success',
   value,
 })
 
+/**
+ * Create a failure parsing result.
+ * @example
+ * ```ts
+ * const customParser: Parser<number> = (data) => {
+ *   if (typeof data === 'number') {
+ *    return success(data)
+ *   }
+ *   return failure('Expected a number')
+ * }
+ * ```
+ * @param message
+ */
 export const failure = (message: string): ParseFailure => ({
   tag: 'failure',
   error: {
@@ -52,12 +109,6 @@ export const failure = (message: string): ParseFailure => ({
     path: [],
   },
 })
-
-/**
- * *****************************
- * Utilities
- * *****************************
- */
 
 /**
  * Check if the result is a success


### PR DESCRIPTION

Adding a property `error` to success to that we can discriminate based on it with TS not complaining:

```ts
export type ParseSuccess<T> = {
  tag: 'success'
  value: T
  error?: never
}
```
