### PR TITLE
fix: error propagation, path tracking, and nonEmptyArray parser

### DIFF
--- a/packages/pure-parse/src/common/lazy.ts
+++ b/packages/pure-parse/src/common/lazy.ts
@@ -28,7 +28,7 @@ export const lazy = <T extends (...args: never[]) => unknown>(
 ): T => {
   let fn: T | undefined
   return ((...args) => {
-    if (!fn) {
+    if (fn === undefined) {
       fn = constructFn()
     }
     return fn(...args)

--- a/packages/pure-parse/src/memoization/parsers.ts
+++ b/packages/pure-parse/src/memoization/parsers.ts
@@ -2,6 +2,7 @@ import { memoizeValidatorConstructor } from './memo'
 import {
   array,
   dictionary,
+  nonEmptyArray,
   object,
   objectCompiled,
   objectStrict,
@@ -19,4 +20,4 @@ export const objectStrictCompiledMemo =
 export const dictionaryMemo = memoizeValidatorConstructor(dictionary)
 export const tupleMemo = memoizeValidatorConstructor(tuple)
 export const arrayMemo = memoizeValidatorConstructor(array)
-// TODO export const nonEmptyArrayMemo = memoizeValidatorConstructor(nonEmptyArray)
+export const nonEmptyArrayMemo = memoizeValidatorConstructor(nonEmptyArray)

--- a/packages/pure-parse/src/parsers/arrays.test.ts
+++ b/packages/pure-parse/src/parsers/arrays.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, test } from 'vitest'
-import { array } from './arrays'
+import { array, nonEmptyArray } from './arrays'
 import { failure, success } from './ParseResult'
 import { equals } from './equals'
 import { parseString } from './primitives'
 import { withDefault } from './withDefault'
+import { Infer } from '../common'
+import { Equals } from '../internals'
 
 describe('arrays', () => {
   it('validates when all elements pass validation', () => {
@@ -40,6 +42,50 @@ describe('arrays', () => {
       }),
     )
   })
+  describe('nonEmptyArray', () => {
+    it('validates non-empty arrays', () => {
+      expect(nonEmptyArray(parseString)(['a'])).toEqual(
+        expect.objectContaining({ tag: 'success', value: ['a'] }),
+      )
+      expect(nonEmptyArray(parseString)(['a', 'b'])).toEqual(
+        expect.objectContaining({ tag: 'success', value: ['a', 'b'] }),
+      )
+    })
+    it('invalidates empty arrays', () => {
+      expect(nonEmptyArray(parseString)([])).toEqual(
+        expect.objectContaining({ tag: 'failure' }),
+      )
+    })
+    it('invalidates non-arrays', () => {
+      ;[1, 'a', null, undefined, {}].forEach((data) => {
+        expect(nonEmptyArray(parseString)(data)).toEqual(
+          expect.objectContaining({ tag: 'failure' }),
+        )
+      })
+    })
+    it('invalidates arrays with invalid elements', () => {
+      expect(nonEmptyArray(parseString)([1])).toEqual(
+        expect.objectContaining({ tag: 'failure' }),
+      )
+    })
+    it('reports element errors with path', () => {
+      expect(nonEmptyArray(parseString)([1])).toEqual(
+        expect.objectContaining({
+          tag: 'failure',
+          error: expect.objectContaining({
+            path: [{ tag: 'array', index: 0 }],
+          }),
+        }),
+      )
+    })
+    describe('types', () => {
+      it('infers a non-empty tuple type', () => {
+        const parse = nonEmptyArray(parseString)
+        const t: Equals<Infer<typeof parse>, [string, ...string[]]> = true
+      })
+    })
+  })
+
   describe('errors', () => {
     it('reports non-arrays', () => {
       const parse = array(parseString)

--- a/packages/pure-parse/src/parsers/arrays.ts
+++ b/packages/pure-parse/src/parsers/arrays.ts
@@ -23,3 +23,24 @@ export const array =
     }
     return success(dataOutput as T[])
   }
+
+/**
+ * Validate non-empty arrays
+ * @return a function that parses non-empty arrays
+ * @param parseItem
+ */
+export const nonEmptyArray =
+  <T>(parseItem: Parser<T>): Parser<[T, ...T[]]> =>
+  (data) => {
+    if (!Array.isArray(data)) {
+      return failure('Expected array')
+    }
+    if (data.length === 0) {
+      return failure('Expected non-empty array')
+    }
+    const result = array(parseItem)(data)
+    if (result.tag === 'failure') {
+      return result
+    }
+    return success(result.value as [T, ...T[]])
+  }

--- a/packages/pure-parse/src/parsers/arrays.ts
+++ b/packages/pure-parse/src/parsers/arrays.ts
@@ -1,5 +1,12 @@
 import { Parser } from './Parser'
-import { failure, ParseSuccess, propagateFailure, success } from './ParseResult'
+import {
+  failure,
+  ParseResult,
+  ParseSuccess,
+  propagateFailure,
+  success,
+} from './ParseResult'
+import { isArray } from '../guards'
 
 /**
  * Validate arrays
@@ -26,21 +33,29 @@ export const array =
 
 /**
  * Validate non-empty arrays
+ * @example
+ * ```ts
+ * const parseNonEmptyNumberArray = parseNonEmptyArray(parseNumber)
+ *
+ * parseNonEmptyNumberArray([1,2,3]) // -> ParseSuccess<[number, ...number[]]>
+ * parseNonEmptyNumberArray([1]) // -> ParseSuccess<[number, ...number[]]>
+ *
+ * parseNonEmptyNumberArray([]) // -> ParseFailure
+ * parseNonEmptyNumberArray(['a']) // -> ParseFailure
+ * parseNonEmptyNumberArray(1) // -> ParseFailure
+ * ```
  * @return a function that parses non-empty arrays
  * @param parseItem
  */
-export const nonEmptyArray =
-  <T>(parseItem: Parser<T>): Parser<[T, ...T[]]> =>
-  (data) => {
-    if (!Array.isArray(data)) {
+export const nonEmptyArray = <T>(parseItem: Parser<T>): Parser<[T, ...T[]]> => {
+  const parseTArray = array(parseItem)
+  return (data) => {
+    if (!isArray(data)) {
       return failure('Expected array')
     }
     if (data.length === 0) {
       return failure('Expected non-empty array')
     }
-    const result = array(parseItem)(data)
-    if (result.tag === 'failure') {
-      return result
-    }
-    return success(result.value as [T, ...T[]])
+    return parseTArray(data) as ParseResult<[T, ...T[]]>
   }
+}

--- a/packages/pure-parse/src/parsers/dictionary.test.ts
+++ b/packages/pure-parse/src/parsers/dictionary.test.ts
@@ -221,6 +221,17 @@ describe('record', () => {
       )
     })
   })
+  describe('inherited properties', () => {
+    it('ignores inherited enumerable properties', () => {
+      const proto = { inherited: 'x' }
+      const data = Object.create(proto)
+      data.own = 'y'
+      expect(dictionary(parseString, parseString)(data)).toEqual(
+        expect.objectContaining({ tag: 'success', value: { own: 'y' } }),
+      )
+    })
+  })
+
   describe('error handling', () => {
     test('that the error points to the object when it is not an object', () => {
       expect(dictionary(parseString, parseBoolean)(1)).toEqual(
@@ -234,7 +245,7 @@ describe('record', () => {
     })
     describe('property errors', () => {
       describe('keys', () => {
-        test('values', () => {
+        test('points to the failing key', () => {
           expect(
             dictionary(
               equals('a'),
@@ -246,35 +257,48 @@ describe('record', () => {
             expect.objectContaining({
               tag: 'failure',
               error: expect.objectContaining({
-                path: [
-                  {
-                    tag: 'object',
-                    key: 'b',
-                  },
-                ],
+                path: [{ tag: 'object', key: 'b' }],
+              }),
+            }),
+          )
+        })
+        test('preserves the inner parser error message', () => {
+          const parseExact: Parser<'a'> = (data) =>
+            data === 'a' ? success('a') : failure('Expected exactly "a"')
+          expect(
+            dictionary(parseExact, parseBoolean)({ b: true }),
+          ).toEqual(
+            expect.objectContaining({
+              tag: 'failure',
+              error: expect.objectContaining({
+                message: 'Expected exactly "a"',
               }),
             }),
           )
         })
       })
-      test('values', () => {
+      test('points to the failing value', () => {
         expect(
-          dictionary(
-            parseString,
-            parseBoolean,
-          )({
-            a: 1,
-          }),
+          dictionary(parseString, parseBoolean)({ a: 1 }),
         ).toEqual(
           expect.objectContaining({
             tag: 'failure',
             error: expect.objectContaining({
-              path: [
-                {
-                  tag: 'object',
-                  key: 'a',
-                },
-              ],
+              path: [{ tag: 'object', key: 'a' }],
+            }),
+          }),
+        )
+      })
+      test('preserves the inner parser error message', () => {
+        const parseExact: Parser<true> = (data) =>
+          data === true ? success(true) : failure('Expected exactly true')
+        expect(
+          dictionary(parseString, parseExact)({ a: false }),
+        ).toEqual(
+          expect.objectContaining({
+            tag: 'failure',
+            error: expect.objectContaining({
+              message: 'Expected exactly true',
             }),
           }),
         )

--- a/packages/pure-parse/src/parsers/dictionary.ts
+++ b/packages/pure-parse/src/parsers/dictionary.ts
@@ -1,5 +1,5 @@
 import { Parser } from './Parser'
-import { failure, propagateFailure, success } from './ParseResult'
+import { failure, ParseResult, propagateFailure, success } from './ParseResult'
 import { isObject } from '../guards'
 
 /**
@@ -12,15 +12,15 @@ import { isObject } from '../guards'
  * @example
  * Validate a dictionary:
  * ```ts
- * const parseDictionary = dictionary(isString, isString)
+ * const parseDictionary = dictionary(parseString, parseString)
  * parseDictionary({ hello: 'world' }) // -> Success
  * parseDictionary({ hello: 1 }) // -> Failure
  * ```
  * @example
  * You can transform the keys and values; for example, to only allow lowercase strings:
  * ```ts
- * const parseLowerCase = (data: unknown): data is Lowercase<string> =>
- *   typeof data === 'string' ? failure('Not a string') : success(data.toLowerCase())
+ * const parseLowerCase = (data: unknown): ParseResult<Lowercase<string>> =>
+ *   typeof data !== 'string' ? failure('Not a string') : success(data.toLowerCase() as Lowercase<string>)
  * const parseDictionary = dictionary(parseLowerCase, parseLowerCase)
  * parseDictionary({ hello: 'world' }) // -> Success<{ hello: 'world' }>
  * parseDictionary({ Hello: 'world' }) // -> Success<{ hello: 'world' }>
@@ -40,19 +40,19 @@ export const dictionary =
       return failure('Expected value to be of type object')
     }
     const resultData: Record<string, V> = {}
-    for (const key in data) {
+    for (const key of Object.keys(data as object)) {
       // This type assertion just makes TypeScript allow us to index with a key
       const value = (data as Record<keyof any, unknown>)[key]
       const parsedKey = parseKey(key)
       if (parsedKey.tag === 'failure') {
-        return propagateFailure(failure('Invalid property key'), {
+        return propagateFailure(parsedKey, {
           tag: 'object',
           key,
         })
       }
       const parsedValue = parseValue(value)
       if (parsedValue.tag === 'failure') {
-        return propagateFailure(failure('Invalid property value'), {
+        return propagateFailure(parsedValue, {
           tag: 'object',
           key,
         })

--- a/packages/pure-parse/src/parsers/dictionary.ts
+++ b/packages/pure-parse/src/parsers/dictionary.ts
@@ -1,5 +1,5 @@
 import { Parser } from './Parser'
-import { failure, ParseResult, propagateFailure, success } from './ParseResult'
+import { failure, propagateFailure, success } from './ParseResult'
 import { isObject } from '../guards'
 
 /**
@@ -13,8 +13,8 @@ import { isObject } from '../guards'
  * Validate a dictionary:
  * ```ts
  * const parseDictionary = dictionary(parseString, parseString)
- * parseDictionary({ hello: 'world' }) // -> Success
- * parseDictionary({ hello: 1 }) // -> Failure
+ * parseDictionary({ hello: 'world' }) // -> ParseSuccess
+ * parseDictionary({ hello: 1 }) // -> ParseFailure
  * ```
  * @example
  * You can transform the keys and values; for example, to only allow lowercase strings:
@@ -22,9 +22,9 @@ import { isObject } from '../guards'
  * const parseLowerCase = (data: unknown): ParseResult<Lowercase<string>> =>
  *   typeof data !== 'string' ? failure('Not a string') : success(data.toLowerCase() as Lowercase<string>)
  * const parseDictionary = dictionary(parseLowerCase, parseLowerCase)
- * parseDictionary({ hello: 'world' }) // -> Success<{ hello: 'world' }>
- * parseDictionary({ Hello: 'world' }) // -> Success<{ hello: 'world' }>
- * parseDictionary({ hello: 'World' }) // -> Success<{ hello: 'world' }>
+ * parseDictionary({ hello: 'world' }) // -> ParseSuccess<{ hello: 'world' }>
+ * parseDictionary({ Hello: 'world' }) // -> ParseSuccess<{ hello: 'world' }>
+ * parseDictionary({ hello: 'World' }) // -> ParseSuccess<{ hello: 'world' }>
  * ```
  * @param parseKey parses every key
  * @param parseValue parses every value

--- a/packages/pure-parse/src/parsers/formatting.test.ts
+++ b/packages/pure-parse/src/parsers/formatting.test.ts
@@ -47,6 +47,13 @@ describe('formatting', () => {
           formatResult(success({ name: 'Alice' }), JSON.stringify),
         ).toEqual('ParseSuccess: {"name":"Alice"}')
       })
+      it('falls back to "<unserializable>" when the custom toString throws', () => {
+        const circular: Record<string, unknown> = {}
+        circular.self = circular
+        expect(formatResult(success(circular), JSON.stringify)).toEqual(
+          'ParseSuccess: <unserializable>',
+        )
+      })
     })
     describe('formatFailure', () => {
       it('should parse a simple string', () => {
@@ -122,6 +129,39 @@ describe('formatting', () => {
     describe('object paths', () => {
       test('depth 1', () => {
         expect(formatPath([{ tag: 'object', key: 'users' }])).toEqual('$.users')
+      })
+      describe('bracket notation for non-identifier keys', () => {
+        test('key with a dot', () => {
+          expect(formatPath([{ tag: 'object', key: 'foo.bar' }])).toEqual(
+            '$["foo.bar"]',
+          )
+        })
+        test('key with a space', () => {
+          expect(formatPath([{ tag: 'object', key: 'foo bar' }])).toEqual(
+            '$["foo bar"]',
+          )
+        })
+        test('key starting with a digit', () => {
+          expect(formatPath([{ tag: 'object', key: '1foo' }])).toEqual(
+            '$["1foo"]',
+          )
+        })
+        test('empty key', () => {
+          expect(formatPath([{ tag: 'object', key: '' }])).toEqual('$[""]')
+        })
+        test('key with double quotes', () => {
+          expect(formatPath([{ tag: 'object', key: 'foo"bar' }])).toEqual(
+            '$["foo\\"bar"]',
+          )
+        })
+        test('nested: identifier then non-identifier', () => {
+          expect(
+            formatPath([
+              { tag: 'object', key: 'users' },
+              { tag: 'object', key: 'display name' },
+            ]),
+          ).toEqual('$.users["display name"]')
+        })
       })
       test('depth 2', () => {
         expect(

--- a/packages/pure-parse/src/parsers/formatting.ts
+++ b/packages/pure-parse/src/parsers/formatting.ts
@@ -30,7 +30,11 @@ export const formatResult = <T>(
 ): string => {
   if (result.tag === 'success') {
     if (!isUndefined(formatValue)) {
-      return `ParseSuccess: ${formatValue(result.value)}`
+      try {
+        return `ParseSuccess: ${formatValue(result.value)}`
+      } catch {
+        return `ParseSuccess: <unserializable>`
+      }
     }
     try {
       return `ParseSuccess: ${result.value}`
@@ -57,13 +61,18 @@ const formatFailure = (failure: ParseFailure): string =>
  * ```
  * @param path
  */
+const isIdentifier = (key: string): boolean =>
+  /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)
+
 export const formatPath = (path: PathSegment[]): string =>
   '$' +
   path
     .map((segment) => {
       switch (segment.tag) {
         case 'object':
-          return `.${segment.key}`
+          return isIdentifier(segment.key)
+            ? `.${segment.key}`
+            : `[${JSON.stringify(segment.key)}]`
         case 'array':
           return `[${segment.index}]`
       }

--- a/packages/pure-parse/src/parsers/instanceOf.ts
+++ b/packages/pure-parse/src/parsers/instanceOf.ts
@@ -6,7 +6,7 @@ import { failure, success } from './ParseResult'
  * @example
  * ```ts
  * const parseError = instanceOf(Error)
- * parseError(new Error()) // -> Success<Error>
+ * parseError(new Error()) // -> ParseSuccess<Error>
  * ```
  * @param constructor the right-hand side argument of the `instanceof` operator
  */

--- a/packages/pure-parse/src/parsers/object.test.ts
+++ b/packages/pure-parse/src/parsers/object.test.ts
@@ -876,6 +876,16 @@ describe('object', () => {
             expect.objectContaining({ tag: 'failure' }),
           )
         })
+        it('includes the extra property key in the error path', () => {
+          expect(objectStrict({})({ a: 'a' })).toEqual(
+            expect.objectContaining({
+              tag: 'failure',
+              error: expect.objectContaining({
+                path: [{ tag: 'object', key: 'a' }],
+              }),
+            }),
+          )
+        })
         it('invalidates objects with missing properties', () => {
           expect(
             objectStrict({ a: parseString, b: parseBoolean })({ a: 'a' }),

--- a/packages/pure-parse/src/parsers/object.ts
+++ b/packages/pure-parse/src/parsers/object.ts
@@ -241,7 +241,10 @@ Parser<OptionalKeys<T> extends undefined ? T : WithOptionalFields<T>> => {
     const dataKeys = Object.keys(data)
     for (const key of dataKeys) {
       if (!schemaKeys.has(key)) {
-        return failure(`Object has an extra property ${JSON.stringify(key)}`)
+        return propagateFailure(
+          failure(`Object has an extra property ${JSON.stringify(key)}`),
+          { tag: 'object', key },
+        )
       }
     }
     return parseLoose(data)
@@ -275,7 +278,10 @@ Parser<OptionalKeys<T> extends undefined ? T : WithOptionalFields<T>> => {
     const dataKeys = Object.keys(data)
     for (const key of dataKeys) {
       if (!schemaKeys.has(key)) {
-        return failure(`Object has an extra property ${JSON.stringify(key)}`)
+        return propagateFailure(
+          failure(`Object has an extra property ${JSON.stringify(key)}`),
+          { tag: 'object', key },
+        )
       }
     }
     return parseLoose(data)


### PR DESCRIPTION
- Implemented `nonEmptyArray`
- In a few cases, preserve the original error when propogating